### PR TITLE
fix numerical safety and edge cases in user_tally and tally.

### DIFF
--- a/source/lib/tally.cpp
+++ b/source/lib/tally.cpp
@@ -300,11 +300,11 @@ bool tally::debugCheck(double E0)
     for (size_t i = 0; i < n; i++)
         sI += *p++;
 
-    p = &A[eLattice](id, 0);
-    for (size_t i = 0; i < ncell; i++)
+    p = A[eLattice].data();
+    for (size_t i = 0; i < n; i++)
         sPh += *p++;
-    p = &A[eStored](id, 0);
-    for (size_t i = 0; i < ncell; i++)
+    p = A[eStored].data();
+    for (size_t i = 0; i < n; i++)
         sPh += *p++;
 
     p = A[eLost].data();

--- a/source/lib/user_tally.cpp
+++ b/source/lib/user_tally.cpp
@@ -124,11 +124,9 @@ bool user_tally::get_bin(const ion &i, const void *pv)
         case cRho:
             v = std::sqrt(pos.x() * pos.x() + pos.y() * pos.y()); // rho = sqrt(x^2+y^2)
             break;
-        case cCosTheta: {
-            float r = pos.norm();
-            v = (r > 0.f) ? pos.z() / r : 0.f;
+        case cCosTheta:
+            v = pos.isZero() ? 0.f : pos.z() / pos.norm();
             break;
-        }
         case cNx:
             v = dir.x(); // x-axis direction cosine
             break;

--- a/source/lib/user_tally.cpp
+++ b/source/lib/user_tally.cpp
@@ -124,9 +124,11 @@ bool user_tally::get_bin(const ion &i, const void *pv)
         case cRho:
             v = std::sqrt(pos.x() * pos.x() + pos.y() * pos.y()); // rho = sqrt(x^2+y^2)
             break;
-        case cCosTheta:
-            v = pos.z() / pos.norm(); // cosTheta = z/r
+        case cCosTheta: {
+            float r = pos.norm();
+            v = (r > 0.f) ? pos.z() / r : 0.f;
             break;
+        }
         case cNx:
             v = dir.x(); // x-axis direction cosine
             break;
@@ -161,13 +163,13 @@ bool user_tally::get_bin(const ion &i, const void *pv)
             break;
         }
 
-        idx[j] = std::upper_bound(bins[j].begin(), bins[j].end(), v) - bins[j].begin()
-                - 1; // id of bin starting from 0
+        ptrdiff_t bin_idx = std::upper_bound(bins[j].begin(), bins[j].end(), v)
+                - bins[j].begin() - 1;
 
-        // valid bin index is  0 <= idx < bin_size
-        // (the last bin is not included by default)
-        if (idx[j] < 0 || idx[j] >= bin_sizes[j])
-            return false; // invalid index -> reject
+        if (bin_idx < 0 || static_cast<size_t>(bin_idx) >= bin_sizes[j])
+            return false;
+
+        idx[j] = static_cast<size_t>(bin_idx);
     }
 
     return true;
@@ -175,7 +177,7 @@ bool user_tally::get_bin(const ion &i, const void *pv)
 
 bool user_tally::push_bins(bin_variable_code c, const bin_vector_t &edges, size_t natoms)
 {
-    if (edges.empty())
+    if (edges.size() < 2)
         return false;
     if (c == cV) {
         // one bin for each target atom id=1,2,...natoms-1


### PR DESCRIPTION
I was going through the user_tally and tally code and found a few things that looked wrong.

- cCosTheta in get_bin() divides by pos.norm() without a zero check silently produces NaN when a particle is at the origin.

- idx is size_t, so idx[j] < 0 in get_bin() is always false. When a value falls below the first edge, upper_bound returns begin() and the -1 wraps to SIZE_MAX, bypassing the bounds check entirely. Using ptrdiff_t as the intermediate fixes it.

- push_bins() only rejects empty edge vectors. One edge gives edges.size() - 1 = 0 bins - valid call, silent no-op. Now requires >= 2.

- In debugCheck(), sPh read only row [id] of eLattice and eStored while sI and sL summed the full array. Energy conservation check would always fail on multi-species targets. Fixed to use .data() + full size like the rest.