### PR TITLE
fix: coord_sys anti-parallel check and tally cell count for 3D grids

### DIFF
--- a/source/include/geometry.h
+++ b/source/include/geometry.h
@@ -656,8 +656,8 @@ struct coord_sys
         vector3 nz = zaxis.normalized();
         vector3 xzn = xzvector.normalized();
 
-        // check if z_axis is nearly parallel to xzvector
-        if (std::abs(nz.dot(xzn) - 1) < 10 * std::numeric_limits<float>::epsilon())
+        // check if z_axis is nearly parallel or anti-parallel to xzvector
+        if (std::abs(std::abs(nz.dot(xzn)) - 1) < 10 * std::numeric_limits<float>::epsilon())
             return false;
 
         vector3 ny = nz.cross(xzn).normalized();

--- a/source/lib/tally.cpp
+++ b/source/lib/tally.cpp
@@ -248,7 +248,7 @@ void tally::operator()(Event ev, const ion &i, const void *pv)
 bool tally::debugCheck(int id, double E0)
 {
     double s(0), sI(0), sPh(0), sL(0);
-    size_t ncell = A[1].dim()[1];
+    size_t ncell = ncells_;
     double *p;
 
     p = &A[eIoniz](id, 0);
@@ -273,7 +273,7 @@ bool tally::debugCheck(int id, double E0)
 bool tally::debugCheck(double E0)
 {
     double s0(0), sI0(0), sPh0(0), sL0(0);
-    size_t ncell = A[1].dim()[1];
+    size_t ncell = ncells_;
     double *p;
     int id = 0;
 
@@ -321,7 +321,7 @@ bool tally::debugCheck(double E0)
 double tally::totalErg(int id)
 {
     double s(0), sI(0), sPh(0), sL(0);
-    size_t ncell = A[1].dim()[1];
+    size_t ncell = ncells_;
     double *p;
 
     p = &A[eIoniz](id, 0);


### PR DESCRIPTION
found these bugs while reading through the geometry and tally code.

**1. geometry.h**
```cpp
// befor
if (std::abs(nz.dot(xzn) - 1) < 10 * std::numeric_limits<float>::epsilon())
// after
if (std::abs(std::abs(nz.dot(xzn)) - 1) < 10 * std::numeric_limits<float>::epsilon())
```

The check only catches parallel vectors (dot = +1), not anti-parallel (dot = -1). When zaxis and xzvector point in opposite directions, nz.cross(xzn) is near-zero and .normalized() produces NaN. Any UserTally with that coordinate system silently scores NaN into the output.

**2. tally.cpp**
```cpp
// before
size_t ncell = A[1].dim()[1];
// after
size_t ncell = ncells_;
```

`dim()[1]` returns only `nx`, not `nx*ny*nz`. For 3D grids debugCheck and totalErg only summed the first x-slice, giving wrong energy totals. 