### PR TITLE
fix: correct periodic distance calculation in grid1D

### DIFF
--- a/source/include/geometry.h
+++ b/source/include/geometry.h
@@ -283,14 +283,7 @@ public:
     float distance(float x1, float x2) const
     {
         float d = std::abs(x1 - x2);
-        if (periodic_ && d < w_ / 2) {
-            float d1 = std::abs(x1 - w_ - x2);
-            if (d1 < d)
-                return d1;
-            d1 = std::abs(x1 + w_ - x2);
-            if (d1 < d)
-                return d1;
-        }
+        if (periodic_) d = std::min(d, w_ - d);
         return d;
     }
 };


### PR DESCRIPTION
Fixes #5.

The condition in `grid1D::distance()` was inverted - it checked periodic images when `d < w_/2`, which is exactly when the direct path is already shortest. So the wrap-around was never actually applied.

Simplified to:
```cpp
float d = std::abs(x1 - x2);
if (periodic_) d = std::min(d, w_ - d);
return d;
```

`std::min` picks the shorter path in one line. 