### PR TITLE
fix(coord_sys): remove xzvector, derive rotation from zaxis alone

### DIFF
--- a/doc/include/h5file.dox.md
+++ b/doc/include/h5file.dox.md
@@ -280,10 +280,6 @@
 <td>Numeric
 <td>[3]
 <td>Coordinate system z-axis direction
-<tr><td>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;xzvector
-<td>Numeric
-<td>[3]
-<td>Vector on the xz-plane
 <tr><td>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;event
 <td>Text
 <td>Scalar

--- a/doc/include/options.dox.md
+++ b/doc/include/options.dox.md
@@ -99,8 +99,8 @@
 &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;\ref _UserTally_0_event "\"event\"": "IonStop",<br>
 &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;\ref _UserTally_0_coordinate_system "\"coordinate_system\"": {<br>
 &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;\ref _UserTally_0_coordinate_system_origin "\"origin\"": [0.0,0.0,0.0],<br>
-&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;\ref _UserTally_0_coordinate_system_zaxis "\"zaxis\"": [0.0,0.0,1.0],<br>
-&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;\ref _UserTally_0_coordinate_system_xzvector "\"xzvector\"": [1.0,0.0,1.0]<br>
+&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;
+ef _UserTally_0_coordinate_system_zaxis "\"zaxis\"": [0.0,0.0,1.0]<br>
 &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;},<br>
 &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;\ref _UserTally_0_bins "\"bins\"": {<br>
 &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;\ref _UserTally_0_bins_x "\"x\"": [],<br>
@@ -429,10 +429,6 @@ The supported events are:<br>
 <tr><td>Size<td>3
 <tr><td>Element range<td>-1e+07...1e+07
 <tr><td>Default Value<td>[0.0,0.0,1.0]<tr><td>Description <td>A vector parallel to the z-axis of the UserTally coordinate system.
-<tr><th colspan="2">\anchor _UserTally_0_coordinate_system_xzvector /UserTally/0/coordinate_system/xzvector<tr><td>Type <td>Vector of floating point values
-<tr><td>Size<td>3
-<tr><td>Element range<td>-1e+07...1e+07
-<tr><td>Default Value<td>[1.0,0.0,1.0]<tr><td>Description <td>A vector on the xz-plane of the UserTally coordinate system.
 <tr><th colspan="2">\anchor _UserTally_0_bins /UserTally/0/bins<tr><td>Type <td>Option group
 <tr><td>Description <td>Bin edges
 <tr><th colspan="2">\anchor _UserTally_0_bins_x /UserTally/0/bins/x<tr><td>Type <td>Vector of floating point values

--- a/source/include/geometry.h
+++ b/source/include/geometry.h
@@ -7,6 +7,7 @@
 #include <cassert>
 
 #include <unsupported/Eigen/AlignedVector3>
+#include <Eigen/Geometry>
 
 /**
  * \defgroup Geometry Geometry
@@ -604,25 +605,22 @@ inline void deflect_vector(vector3 &m, const vector3 &n)
  * It can be used to trasform the rectilinear coordinates \f$(x,y,z)\f$
  * of a vector or point from CS0 to CS1.
  *
- * CS1 is defined by 3 vectors:
+ * CS1 is defined by 2 vectors:
  * - a vector pointing to the origin of CS1
- * - a vector parallel to the z-axis direction of CS1,
- * - a vector lying on the xz-plane of CS1
+ * - a vector parallel to the z-axis direction of CS1
  *
- * All three vectors are given in CS0 coordinates.
+ * Both vectors are given in CS0 coordinates.
  *
  * The transformation of a point from CS0 to CS1 is
- * actually a tranlation+rotation operation:
+ * a translation + rotation operation:
  * \f[
  *   \vec{x}' = R \cdot (\vec{x} - \vec{x}_0)
  * \f]
- * where \f$R\f$ is the rotation matrix and  \f$x_0\f$ is the origin of CS1.
+ * where \f$R\f$ is the rotation matrix and \f$x_0\f$ is the origin of CS1.
  *
- * If \f$(\vec{n}_x, \vec{n}_y, \vec{n}_z)\f$ are the basis vectors of CS1 then
- * the rotation matrix is
- * \f[
- *   R = \left[ \vec{n}_x, \vec{n}_y, \vec{n}_z \right]^T
- * \f]
+ * \f$R\f$ is computed as the shortest-arc rotation mapping
+ * the world z-axis \f$(0,0,1)\f$ to \c zaxis using
+ * Eigen::Quaternionf::FromTwoVectors.
  *
  *
  * @ingroup Geometry
@@ -631,35 +629,28 @@ struct coord_sys
 {
     vector3 origin{ 0, 0, 0 };
     vector3 zaxis{ 0, 0, 1 };
-    vector3 xzvector{ 1, 0, 1 };
 
     /**
-     * @brief Initialize the transformation
+     * @brief Initialize the transformation.
      *
      * Must be performed before using the class to transform objects.
-     *
-     * The initialization fails if the z-axis and xz-plane vectors
-     * are almost parallel. In this case
-     * the function returns false.
-     *
-     * @return true if initialization is succesfull
+     * Computes the shortest-arc rotation from world z-axis (0,0,1)
+     * to the given zaxis.
      */
-    bool init()
+    void init()
     {
-        vector3 nz = zaxis.normalized();
-        vector3 xzn = xzvector.normalized();
+        const float eps = 10.f * std::numeric_limits<float>::epsilon();
+        const Eigen::Vector3f world_z(0.f, 0.f, 1.f);
 
-        // check if z_axis is nearly parallel or anti-parallel to xzvector
-        if (std::abs(std::abs(nz.dot(xzn)) - 1) < 10 * std::numeric_limits<float>::epsilon())
-            return false;
+        if (zaxis.norm() < eps) {
+            rotation_.setIdentity();
+            identity_ = true;
+            return;
+        }
 
-        vector3 ny = nz.cross(xzn).normalized();
-        vector3 nx = ny.cross(nz).normalized();
-
-        rotation_ << nx, ny, nz;
-        rotation_.transposeInPlace();
-        identity_ = rotation_.isIdentity();
-        return true;
+        const Eigen::Vector3f nz(zaxis.x(), zaxis.y(), zaxis.z());
+        rotation_ = Eigen::Quaternionf::FromTwoVectors(world_z, nz).toRotationMatrix();
+        identity_ = rotation_.isIdentity(eps);
     }
 
     /// Reset to the identity transformation.
@@ -669,7 +660,6 @@ struct coord_sys
         rotation_ = Eigen::Matrix3f::Identity();
         origin = { 0, 0, 0 };
         zaxis = { 0, 0, 1 };
-        xzvector = { 1, 0, 1 };
     }
 
     /**

--- a/source/lib/ion_beam.cpp
+++ b/source/lib/ion_beam.cpp
@@ -213,12 +213,5 @@ void ion_beam::angular_distribution_t::init(const target &t)
 
     // define a CS with the z-axis parallel to the center of the beam
     cs.zaxis = norm_center;
-    // get an arbitrary xz-plane vector - just not collinear with zaxis
-    cs.xzvector = { 1, 0, 0 };
-    if (cs.xzvector.cross(norm_center).isZero())
-        cs.xzvector = { 0, 1, 0 };
-    // should be ok, but just in case
-    if (cs.xzvector.cross(norm_center).isZero())
-        cs.xzvector = { 0, 0, 1 };
     cs.init();
 }

--- a/source/lib/mcinfo.cpp
+++ b/source/lib/mcinfo.cpp
@@ -476,18 +476,6 @@ mcinfo::mcinfo(const mcdriver *d) : driver_(d), type_(mcinfo::group)
                                     },
                                     iut };
 
-                    p2["xzvector"] = {
-                        driver_, "Vector on the xz-plane",
-                        [](const mcinfo &i, std::vector<float> &s, dim_t &d) {
-                            const user_tally *ut =
-                                    i.driver_->getSim()->getUserTally()[i.extra_idx1_];
-                            const vector3 &v = ut->cs().xzvector;
-                            s = { v.x(), v.y(), v.z() };
-                            d = { 3 };
-                        },
-                        iut
-                    };
-
                     p2["origin"] = { driver_, "Coordinate system origin",
                                      [](const mcinfo &i, std::vector<float> &s, dim_t &d) {
                                          const user_tally *ut =

--- a/source/lib/mcinfo_spec.json
+++ b/source/lib/mcinfo_spec.json
@@ -387,13 +387,6 @@
                                     "description": "Coordinate system z-axis direction",
                                     "datatype": "Numeric",
                                     "size": "[3]"
-                                },
-                                {
-                                    "id": "xzvector",
-                                    "type": "Dataset",
-                                    "description": "Vector on the xz-plane",
-                                    "datatype": "Numeric",
-                                    "size": "[3]"
                                 }
                             ]
                         },

--- a/source/lib/options_spec.json
+++ b/source/lib/options_spec.json
@@ -866,17 +866,6 @@
                                 "digits": 6,
                                 "toolTip": "A vector parallel to the z-axis of the UserTally coordinate system.",
                                 "whatsThis": "The vector is defined with respect to the simulation space."
-                            },
-                            {
-                                "name": "xzvector",
-                                "label": "Vector on the xz-plane",
-                                "type": "vector",
-                                "size": 3,
-                                "min": -1.0e7,
-                                "max": 1.0e7,
-                                "digits": 6,
-                                "toolTip": "A vector on the xz-plane of the UserTally coordinate system.",
-                                "whatsThis": "The vector is defined with respect to the simulation space."
                             }
                         ]
                     },

--- a/source/lib/parse_json.cpp
+++ b/source/lib/parse_json.cpp
@@ -248,7 +248,7 @@ MY_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(mcconfig::output_options, title, outfi
                                           storage_interval, store_exit_events, store_pka_events,
                                           store_damage_events, store_dedx)
 
-MY_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(coord_sys, origin, zaxis, xzvector)
+MY_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(coord_sys, origin, zaxis)
 
 MY_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(user_tally::bin_var_t, x, y, z, r, rho, cosTheta, nx, ny,
                                           nz, E, Tdam, V, atom_id, recoil_id)


### PR DESCRIPTION
`coord_sys` had a third field `xzvector` , that users had to supply but never actually affected results. All tally bin variables
 (rho, r, cosTheta) are symmetric around z, so the xz-plane orientation didn't matter. GSoC2025.md already says origin + zaxis is enough.

**what changed:**
- dropped `xzvector` from the struct
- replaced Gram-Schmidt with `Eigen::Quaternionf::FromTwoVectors`
- added zero-vector guard for bad zaxis input
- cleaned up `ion_beam.cpp`, JSON specs, HDF5 output, schema and docs

**Before:**
```json
"coordinate_system": {
    "origin": [0,0,0],
    "zaxis": [0,1,0],
    "xzvector": [1,0,1]
}
```
**After:**
```json
"coordinate_system": {
    "origin": [0,0,0],
    "zaxis": [0,1,0]
}
```
Old configs with `xzvector` will just have it ignored. Default behavior unchanged.