### PR TITLE
fix: catch unknown JSON config keys before simulation runs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -67,7 +67,7 @@ Tally:
 
 ### Core lib
 
-- [ ] json parser: un-recognized options should create an error
+- [X] json parser: un-recognized options should create an error
   - This will aid in checking if a .json file is valid OpenTRIM options
   - With the possibility to relax the rule in the future to allow extra/new options
 

--- a/source/cli/main.cpp
+++ b/source/cli/main.cpp
@@ -96,6 +96,7 @@ int main(int argc, char *argv[])
     app.set_version_flag("-v,--version", version_string);
 
     int n(-1), j(-1), s(-1);
+    bool relaxed(false);
     std::string input_config_file, input_file, output_file;
 
     app.add_option("-n", n, "Number of histories to run (overrides config input)");
@@ -105,6 +106,8 @@ int main(int argc, char *argv[])
     app.add_option("-f", input_config_file, "JSON config file");
     app.add_option("-o,--output", output_file, "Output HDF5 file name (overrides config input)");
     app.add_flag("-t,--template", "Print a template JSON config to stdout");
+    app.add_flag("--relaxed", relaxed,
+                 "Allow unrecognized JSON config keys (relaxed validation)");
     CLI11_PARSE(app, argc, argv);
 
     if (app.get_option("--template")->as<bool>()) { // NEW: print configuration and exit
@@ -154,12 +157,12 @@ int main(int argc, char *argv[])
                 cout << "Parsing JSON config from " << input_config_file << endl;
             }
 
-            if (config.parseJSON(is, true, &cerr) != 0)
+            if (config.parseJSON(is, true, &cerr, !relaxed) != 0)
                 return -1;
 
         } else {
 
-            if (config.parseJSON(cin, true, &cerr) != 0)
+            if (config.parseJSON(cin, true, &cerr, !relaxed) != 0)
                 return -1;
         }
 

--- a/source/include/mcdriver.h
+++ b/source/include/mcdriver.h
@@ -115,10 +115,12 @@ struct mcconfig
      *
      * @param js a JSON formatted input stream
      * @param doValidation if true the function calls validate()
-     * @param os optional pointer to an output stream to recieve error messages
+    * @param os optional pointer to an output stream to recieve error messages
+    * @param strict if true reject unrecognized option keys during config validation
      * @return 0 if succesfull, negative value otherwise
      */
-    int parseJSON(std::istream &js, bool doValidation = true, std::ostream *os = nullptr);
+    int parseJSON(std::istream &js, bool doValidation = true, std::ostream *os = nullptr,
+               bool strict = true);
 
     /// Pretty print JSON formattet mcconfig to a stream
     void printJSON(std::ostream &os) const;

--- a/source/lib/h5serialize.cpp
+++ b/source/lib/h5serialize.cpp
@@ -320,7 +320,7 @@ int mcdriver::load(const std::string &h5filename, std::ostream *os)
         {
             std::string json = h5e::load<std::string>(h5f, "/run_info/json_config");
             std::stringstream is(json);
-            if (opt.parseJSON(is, true, os) != 0)
+            if (opt.parseJSON(is, true, os, false) != 0)
                 return -1;
         }
 

--- a/source/lib/parse_json.cpp
+++ b/source/lib/parse_json.cpp
@@ -34,14 +34,14 @@ void to_json(ojson &j, const mcconfig &p);
 void from_json(const ojson &j, mcconfig &p);
 
 // validate json config against option specs
-int validate_json_config(const std::string &specs, const ojson &j);
+int validate_json_config(const std::string &specs, const ojson &j, bool strict = true);
 
-int mcconfig::parseJSON(std::istream &js, bool doValidation, std::ostream *os)
+int mcconfig::parseJSON(std::istream &js, bool doValidation, std::ostream *os, bool strict)
 {
     if (os) {
         try {
             ojson j = ojson::parse(js, nullptr, true, true);
-            validate_json_config(options_spec(), j);
+            validate_json_config(options_spec(), j, strict);
             *this = j.template get<mcconfig>();
             if (doValidation)
                 validate();
@@ -56,7 +56,7 @@ int mcconfig::parseJSON(std::istream &js, bool doValidation, std::ostream *os)
         }
     } else {
         ojson j = ojson::parse(js, nullptr, true, true);
-        validate_json_config(options_spec(), j);
+        validate_json_config(options_spec(), j, strict);
         *this = j.template get<mcconfig>();
         if (doValidation)
             validate();
@@ -542,7 +542,7 @@ int validate_simple_value(const ojson &spec, ojson::const_reference &vref, const
 }
 
 int validate_helper(const ojson &spec, const ojson &opt, const std::string &path = std::string(),
-                    bool is_item = false)
+                    bool strict = true)
 {
     mcconfig::option_type_t type;
     spec["type"].get_to(type);
@@ -551,13 +551,38 @@ int validate_helper(const ojson &spec, const ojson &opt, const std::string &path
 
     if (type == mcconfig::tStruct) {
         std::string next_path = path.empty() ? "/" : path + name + "/";
+
+        // reverse check: reject user-supplied keys that are not in spec
+        std::vector<std::string> known_names;
+        for (auto it = spec["fields"].begin(); it != spec["fields"].end(); ++it)
+            known_names.push_back((*it)["name"].template get<std::string>());
+
+        if (strict) {
+            try {
+                std::string struct_path = path + name;
+                const ojson &struct_node =
+                        path.empty() ? opt : opt.at(ojson::json_pointer(struct_path));
+
+                if (struct_node.is_object()) {
+                    for (auto &[key, val] : struct_node.items()) {
+                        if (std::find(known_names.begin(), known_names.end(), key)
+                            == known_names.end()) {
+                            std::ostringstream msg;
+                            msg << "(" << (path.empty() ? "" : struct_path) << "/" << key
+                                << ") ";
+                            msg << "Unrecognized option " << std::quoted(key) << std::endl;
+                            throw std::invalid_argument(msg.str());
+                        }
+                    }
+                }
+            } catch (const ojson::out_of_range &) {
+                // Struct section not provided by user input; defaults apply.
+            }
+        }
+
         for (auto it = spec["fields"].begin(); it != spec["fields"].end(); ++it) {
             const ojson &opt_spec = *it;
-            // std::string next_path(path);
-            // next_path += opt_spec["name"].template get<std::string>();
-            // std::string typeName = opt_spec["type"].template get<std::string>();
-
-            validate_helper(opt_spec, opt, next_path);
+            validate_helper(opt_spec, opt, next_path, strict);
         }
         return 0;
     }
@@ -589,23 +614,53 @@ int validate_helper(const ojson &spec, const ojson &opt, const std::string &path
             throw std::invalid_argument(msg.str());
         }
 
+        std::vector<std::string> item_known_names;
+        for (auto it = item_spec["fields"].begin(); it != item_spec["fields"].end(); ++it)
+            item_known_names.push_back((*it)["name"].template get<std::string>());
+
         // we accept arrays of objects OR a single object (equiv. to array of size 1)
         if (vref.is_array()) {
             for (int k = 0; k < vref.size(); ++k) {
-                std::string item_path = jpath + "/";
-                item_path += std::to_string(k);
-                item_path += "/";
+                std::string item_obj_path = jpath + "/" + std::to_string(k);
+                std::string item_path = item_obj_path + "/";
+                if (strict) {
+                    const ojson &item_node = opt.at(ojson::json_pointer(item_obj_path));
+                    if (item_node.is_object()) {
+                        for (auto &[key, val] : item_node.items()) {
+                            if (std::find(item_known_names.begin(), item_known_names.end(), key)
+                                == item_known_names.end()) {
+                                std::ostringstream msg;
+                                msg << "(" << item_obj_path << "/" << key << ") ";
+                                msg << "Unrecognized option " << std::quoted(key) << std::endl;
+                                throw std::invalid_argument(msg.str());
+                            }
+                        }
+                    }
+                }
+
                 for (auto it = item_spec["fields"].begin(); it != item_spec["fields"].end(); ++it) {
                     const ojson &opt_spec = *it;
-                    validate_helper(opt_spec, opt, item_path);
+                    validate_helper(opt_spec, opt, item_path, strict);
                 }
             }
             return 0;
         } else {
+            if (strict && vref.is_object()) {
+                for (auto &[key, val] : vref.items()) {
+                    if (std::find(item_known_names.begin(), item_known_names.end(), key)
+                        == item_known_names.end()) {
+                        std::ostringstream msg;
+                        msg << "(" << jpath << "/" << key << ") ";
+                        msg << "Unrecognized option " << std::quoted(key) << std::endl;
+                        throw std::invalid_argument(msg.str());
+                    }
+                }
+            }
+
             std::string item_path = jpath + "/";
             for (auto it = item_spec["fields"].begin(); it != item_spec["fields"].end(); ++it) {
                 const ojson &opt_spec = *it;
-                validate_helper(opt_spec, opt, item_path);
+                validate_helper(opt_spec, opt, item_path, strict);
             }
             return 0;
         }
@@ -614,10 +669,10 @@ int validate_helper(const ojson &spec, const ojson &opt, const std::string &path
     return validate_simple_value(spec, vref, jpath);
 }
 
-int validate_json_config(const std::string &specs, const ojson &j)
+int validate_json_config(const std::string &specs, const ojson &j, bool strict)
 {
     std::istringstream is(specs);
     ojson json_specs = ojson::parse(is, nullptr, true, true);
-    validate_helper(json_specs, j);
+    validate_helper(json_specs, j, std::string(), strict);
     return 0;
 }


### PR DESCRIPTION
Typos in the config ran silently with wrong defaults. No warning, nothing.

```json
{ "Run": { "max_no_inos": 1000000 } }
```
`max_no_ions` stays at 100. Simulation runs. You'd never know.

`validate_helper()` now checks the user's keys against the spec too. Unknown key then error with exact path, before anything runs.
```
$ echo '{"Simulaton": {}}' | opentrim
Invalid option: (/Simulaton) Unrecognized option "Simulaton"
```
`--relaxed` flag added to CLI if you need to bypass it.
HDF5 resume always relaxed so old checkpoint files still load fine.

Closes TODO: "json parser: un-recognized options should create an error"