### PR TITLE
cli: handle SIGINT so partial results are saved on Ctrl-C

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -103,7 +103,7 @@ Tally:
   - [ ] Pressing add material presents to the user a selection/search function to discover & select
 
 - CLI:
-  - [ ] Block Ctrl-C signal so that data is saved before the program is aborted
+  - [X] Block Ctrl-C signal so that data is saved before the program is aborted
 
 - General
   - [ ] Provide progress info for HDF5 i/o operations

--- a/source/cli/main.cpp
+++ b/source/cli/main.cpp
@@ -12,6 +12,8 @@
 #  include <cstdio>
 #endif
 
+#include <csignal>
+
 using std::cerr;
 using std::cin;
 using std::cout;
@@ -62,6 +64,14 @@ void progress_callback(const mcdriver &d, void *)
 {
     info.update(d);
     info.print();
+}
+
+static mcdriver *g_driver_ptr = nullptr;
+
+static void sigint_handler(int)
+{
+    if (g_driver_ptr)
+        g_driver_ptr->abort();
 }
 
 int main(int argc, char *argv[])
@@ -184,13 +194,22 @@ int main(int argc, char *argv[])
     info.init(D);
     info.print();
 
+    // Install handler: Ctrl-C calls abort() instead of killing the process immediately.
+    g_driver_ptr = &D;
+    signal(SIGINT, sigint_handler);
+
     D.exec(progress_callback, 200);
 
-    const mcdriver::run_data &rd = D.run_history().back();
-    cout << endl << endl << "Completed " << rd.total_ion_count << " ion histories." << endl;
-    cout << "Threads: " << D.config().Run.threads << endl;
-    cout << "Cpu time (s):  " << rd.cpu_time << ",\t" << "Ions/cpu-s:  " << rd.ips << endl;
-    cout << "Real time (s): " << info.elapsed() << ",\t" << "Ions/real-s: " << info.ips() << endl;
+    // Guard: run_history is empty only if exec() returned early (n_end <= n_start).
+    // For all other exits including SIGINT abort, exec() pushes before returning.
+    if (!D.run_history().empty()) {
+        const mcdriver::run_data &rd = D.run_history().back();
+        cout << endl << endl << "Completed " << rd.total_ion_count << " ion histories." << endl;
+        cout << "Threads: " << D.config().Run.threads << endl;
+        cout << "Cpu time (s):  " << rd.cpu_time << ",\t" << "Ions/cpu-s:  " << rd.ips << endl;
+        cout << "Real time (s): " << info.elapsed() << ",\t" << "Ions/real-s: " << info.ips() << endl;
+    }
+    // D.save() runs regardless and writes whatever was accumulated before abort.
     cout << "Storing results in " << D.outFileName() << " ...";
     cout.flush();
     D.save(D.outFileName(), &cerr);


### PR DESCRIPTION
Closes TODO item: "Block Ctrl-C signal so that data is saved before the program is aborted"

Ctrl-C triggered the default OS handler - instant kill, no save. The abort machinery was already there (`mcdriver::abort()`, shared `abort_flag_` atomic). It just wasn't wired to a signal handler.

Three additions to `source/cli/main.cpp` - `#include <csignal>`, a file-scope handler calling `g_driver_ptr->abort()`, installed just before `exec()`. `run_history()` access is guarded since exec returns early before pushing when `n_end <= n_start`. `D.save()` runs regardless.

Tested - 1 MeV H on Fe, 5M ion run, Ctrl-C after ~6 seconds:
 
```
./build/source/cli/opentrim -f source/gui/examples/1MeV_H_on_Fe.json -n 5000000
^C
Completed 961 ion histories.
Threads: 4
Cpu time (s):  24.40,   Ions/cpu-s:  39.38
Real time (s): 6.13,    Ions/real-s: 156.64
Storing results in out.h5 ... OK.
```