### PR TITLE
feat(gui): ion count and CPU time run limits in Run panel

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -51,7 +51,7 @@
 - [ ] Program icon/logo
 - [ ] Desktop integration
 
-- [ ] Implement function to set limit on ion histories or time to run
+- [X] Implement function to set limit on ion histories or time to run
   E.g., the "Ions to run" label can become a ToolButton, allowing the user
   to set the limit either on the # of ions or in time
 

--- a/source/gui/mcdriverobj.cpp
+++ b/source/gui/mcdriverobj.cpp
@@ -45,7 +45,7 @@ void McDriverObj::setOptions(const mcconfig &opt, bool initFromFile)
 {
     options_ = opt;
     if (initFromFile) {
-        max_ions_ = opt.Run.max_no_ions;
+        setMaxIons(opt.Run.max_no_ions);
         nThreads_ = opt.Run.threads;
         seed_ = opt.Run.seed;
         updInterval_ = opt.Output.storage_interval;

--- a/source/gui/mcdriverobj.cpp
+++ b/source/gui/mcdriverobj.cpp
@@ -2,6 +2,7 @@
 
 #include "mcdriver.h"
 
+#include <climits>
 #include <fstream>
 
 #include <QFile>
@@ -21,7 +22,8 @@ McDriverObj::McDriverObj()
       max_ions_(100),
       nThreads_(1),
       seed_(123456789),
-      updInterval_(1000)
+      updInterval_(1000),
+      max_cpu_time_(0)
 {
     // internal start signal connection
     connect(this, &McDriverObj::startSignal, this, &McDriverObj::start_, Qt::QueuedConnection);
@@ -49,6 +51,9 @@ void McDriverObj::setOptions(const mcconfig &opt, bool initFromFile)
         nThreads_ = opt.Run.threads;
         seed_ = opt.Run.seed;
         updInterval_ = opt.Output.storage_interval;
+        setMaxCpuTime(opt.Run.max_cpu_time > static_cast<size_t>(INT_MAX)
+                              ? INT_MAX
+                              : static_cast<int>(opt.Run.max_cpu_time));
     }
     emit configChanged();
     setModified(true);
@@ -61,6 +66,7 @@ std::string McDriverObj::json() const
     opt.Run.seed = seed_;
     opt.Run.threads = nThreads_;
     opt.Output.storage_interval = updInterval_;
+    opt.Run.max_cpu_time = static_cast<size_t>(max_cpu_time_);
     return opt.toJSON();
 }
 
@@ -143,6 +149,7 @@ bool McDriverObj::validateOptions(QString *msg) const
     opt.Run.seed = seed_;
     opt.Run.threads = nThreads_;
     opt.Output.storage_interval = updInterval_;
+    opt.Run.max_cpu_time = static_cast<size_t>(max_cpu_time_);
 
     bool isValid = true;
 
@@ -283,6 +290,7 @@ void McDriverObj::saveJson(const QString &fname)
         opt.Run.seed = seed_;
         opt.Run.threads = nThreads_;
         opt.Output.storage_interval = updInterval_;
+        opt.Run.max_cpu_time = static_cast<size_t>(max_cpu_time_);
     }
 
     opt.Output.outfilename = fileName().toStdString();
@@ -347,6 +355,7 @@ void McDriverObj::start(bool b)
             opt.Run.seed = seed_;
             opt.Run.threads = nThreads_;
             opt.Output.storage_interval = updInterval_;
+            opt.Run.max_cpu_time = static_cast<size_t>(max_cpu_time_);
 
             driver_->init(opt);
 
@@ -360,6 +369,7 @@ void McDriverObj::start(bool b)
             mcconfig::run_options par = driver_->config().Run;
             par.max_no_ions = max_ions_;
             par.threads = nThreads_;
+            par.max_cpu_time = static_cast<size_t>(max_cpu_time_);
             driver_->setRunOptions(par);
 
             mcconfig::output_options opts = driver_->config().Output;

--- a/source/gui/mcdriverobj.h
+++ b/source/gui/mcdriverobj.h
@@ -1,6 +1,7 @@
 #ifndef MCDRIVEROBJ_H
 #define MCDRIVEROBJ_H
 
+#include <algorithm>
 #include <chrono>
 
 #include <QObject>
@@ -25,6 +26,10 @@ class McDriverObj : public QObject
     Q_OBJECT
 
 public:
+    // Largest integer exactly representable as double (53-bit mantissa).
+    // QDoubleSpinBox uses double internally; larger integers lose precision.
+    static constexpr quint64 kMaxExactIons = 1ULL << 53;
+
     // helper class for getting real-time info
     // for the running simulation
     class running_sim_info
@@ -131,7 +136,7 @@ public:
     const mccore *getSim() const;
 
     // get run parameters
-    size_t maxIons() const { return max_ions_; }
+    quint64 maxIons() const { return max_ions_; }
     int nThreads() const { return nThreads_; }
     int seed() const { return seed_; }
     int updInterval() const { return updInterval_; }
@@ -139,7 +144,10 @@ public:
 public slots:
 
     // set run parameters
-    void setMaxIons(int n) { max_ions_ = n; };
+    void setMaxIons(quint64 n)
+    {
+        max_ions_ = (n >= 1) ? std::min(n, kMaxExactIons) : 1;
+    };
     void setNThreads(int n) { nThreads_ = n; };
     void setSeed(int n) { seed_ = n; }
     void setUpdInterval(int n) { updInterval_ = n; }
@@ -187,7 +195,7 @@ private:
     int io_ret_;
     std::string io_err_;
 
-    size_t max_ions_;
+    quint64 max_ions_;
     int nThreads_;
     int seed_;
     int updInterval_;

--- a/source/gui/mcdriverobj.h
+++ b/source/gui/mcdriverobj.h
@@ -140,6 +140,7 @@ public:
     int nThreads() const { return nThreads_; }
     int seed() const { return seed_; }
     int updInterval() const { return updInterval_; }
+    int maxCpuTime() const { return max_cpu_time_; }
 
 public slots:
 
@@ -151,6 +152,7 @@ public slots:
     void setNThreads(int n) { nThreads_ = n; };
     void setSeed(int n) { seed_ = n; }
     void setUpdInterval(int n) { updInterval_ = n; }
+    void setMaxCpuTime(int n) { max_cpu_time_ = std::max(0, n); }
 
 private slots:
 
@@ -199,6 +201,7 @@ private:
     int nThreads_;
     int seed_;
     int updInterval_;
+    int max_cpu_time_;
 
     // run info
     running_sim_info info_;

--- a/source/gui/simcontrolwidget.cpp
+++ b/source/gui/simcontrolwidget.cpp
@@ -5,6 +5,7 @@
 #include "optionsmodel.h"
 #include "simulationoptionsview.h"
 
+#include <climits>
 #include <QTimer>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -90,6 +91,15 @@ SimControlWidget::SimControlWidget(MainUI *ui, QWidget *parent)
     sbSeed = (QSpinBox *)item->createEditor(this);
     simCtrls.push_back(sbSeed);
 
+    // 0 means no time limit.
+    sbMaxTime = new QSpinBox;
+    sbMaxTime->setRange(0, INT_MAX);
+    sbMaxTime->setSingleStep(60);
+    sbMaxTime->setSuffix(" s");
+    sbMaxTime->setSpecialValueText("no limit");
+    sbMaxTime->setValue(driver_->maxCpuTime());
+    sbMaxTime->setToolTip("Stop after this many CPU seconds. With N threads, wall time will be ~1/N of this value. 0 means no time limit.");
+
     /* Create Info items */
 
     QStringList ctrlLabels{ "Ions to run", "Threads", "Upd period (ms)", "Seed" };
@@ -164,6 +174,13 @@ SimControlWidget::SimControlWidget(MainUI *ui, QWidget *parent)
                 }
             }
             {
+                QHBoxLayout *hbox3 = new QHBoxLayout;
+                hbox3->addWidget(new QLabel("Max CPU time (s)"));
+                hbox3->addWidget(sbMaxTime);
+                hbox3->addStretch();
+                vbox->addLayout(hbox3);
+            }
+            {
                 QHBoxLayout *hbox2 = new QHBoxLayout;
                 hbox2->addWidget(runIndicator);
                 hbox2->addWidget(progressBar);
@@ -203,6 +220,8 @@ SimControlWidget::SimControlWidget(MainUI *ui, QWidget *parent)
     connect(sbSeed, QOverload<int>::of(&QSpinBox::valueChanged), driver_, &McDriverObj::setSeed);
     connect(sbUpdInterval, QOverload<int>::of(&QSpinBox::valueChanged), driver_,
             &McDriverObj::setUpdInterval);
+    connect(sbMaxTime, QOverload<int>::of(&QSpinBox::valueChanged), driver_,
+            &McDriverObj::setMaxCpuTime);
 }
 
 void SimControlWidget::onStart(bool b)
@@ -289,6 +308,7 @@ void SimControlWidget::onDriverStatusChanged()
     sbNThreads->setEnabled(st != McDriverObj::mcRunning);
     sbUpdInterval->setEnabled(st != McDriverObj::mcRunning);
     sbSeed->setEnabled(st == McDriverObj::mcReset);
+    sbMaxTime->setEnabled(st != McDriverObj::mcRunning);
 }
 
 QString mytimefmt_(double t, bool ceil = false)
@@ -343,4 +363,5 @@ void SimControlWidget::revert()
     sbNThreads->setValue(driver_->nThreads());
     sbSeed->setValue(driver_->seed());
     sbUpdInterval->setValue(driver_->updInterval());
+    sbMaxTime->setValue(driver_->maxCpuTime());
 }

--- a/source/gui/simcontrolwidget.cpp
+++ b/source/gui/simcontrolwidget.cpp
@@ -14,6 +14,7 @@
 #include <QLineEdit>
 #include <QToolButton>
 #include <QProgressBar>
+#include <QDoubleSpinBox>
 #include <QSpinBox>
 #include <QLabel>
 #include <QStyle>
@@ -64,13 +65,17 @@ SimControlWidget::SimControlWidget(MainUI *ui, QWidget *parent)
     // because they can be overriden every time we run the sim
     OptionsModel *model = mainui_->optionsModel;
     QModelIndex driverOptionsIdx = model->index("Run");
-    QModelIndex idx = model->index("max_no_ions", 0, driverOptionsIdx);
-    OptionsItem *item = model->getItem(idx);
-    sbIons = (QSpinBox *)item->createEditor(this);
+    // QSpinBox is limited to INT_MAX. Used QDoubleSpinBox with 0 decimals
+    // to support integer values up to 2^53 exactly
+    sbIons = new QDoubleSpinBox;
+    sbIons->setDecimals(0);
+    sbIons->setRange(1, static_cast<double>(McDriverObj::kMaxExactIons));
+    sbIons->setSingleStep(100'000);
+    sbIons->setValue(static_cast<double>(driver_->maxIons()));
     simCtrls.push_back(sbIons);
 
-    idx = model->index("threads", 0, driverOptionsIdx);
-    item = model->getItem(idx);
+    QModelIndex idx = model->index("threads", 0, driverOptionsIdx);
+    OptionsItem *item = model->getItem(idx);
     sbNThreads = (QSpinBox *)item->createEditor(this);
     simCtrls.push_back(sbNThreads);
 
@@ -191,7 +196,8 @@ SimControlWidget::SimControlWidget(MainUI *ui, QWidget *parent)
 
     connect(driver_, &McDriverObj::configChanged, this, &SimControlWidget::revert);
 
-    connect(sbIons, QOverload<int>::of(&QSpinBox::valueChanged), driver_, &McDriverObj::setMaxIons);
+    connect(sbIons, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
+            [this](double v) { driver_->setMaxIons(static_cast<quint64>(v)); });
     connect(sbNThreads, QOverload<int>::of(&QSpinBox::valueChanged), driver_,
             &McDriverObj::setNThreads);
     connect(sbSeed, QOverload<int>::of(&QSpinBox::valueChanged), driver_, &McDriverObj::setSeed);
@@ -333,7 +339,7 @@ void SimControlWidget::onSimulationCreated()
 
 void SimControlWidget::revert()
 {
-    sbIons->setValue(driver_->maxIons());
+    sbIons->setValue(static_cast<double>(driver_->maxIons()));
     sbNThreads->setValue(driver_->nThreads());
     sbSeed->setValue(driver_->seed());
     sbUpdInterval->setValue(driver_->updInterval());

--- a/source/gui/simcontrolwidget.h
+++ b/source/gui/simcontrolwidget.h
@@ -5,6 +5,7 @@
 
 class QLineEdit;
 class QLabel;
+class QDoubleSpinBox;
 class QSpinBox;
 class QProgressBar;
 class QToolButton;
@@ -35,11 +36,11 @@ private:
     McDriverObj *driver_;
     QToolButton *btStart;
     QToolButton *btReset;
-    QSpinBox *sbIons;
+    QDoubleSpinBox *sbIons;
     QSpinBox *sbNThreads;
     QSpinBox *sbSeed;
     QSpinBox *sbUpdInterval;
-    std::vector<QSpinBox *> simCtrls;
+    std::vector<QWidget *> simCtrls;
     std::vector<QLineEdit *> simIndicators;
     QProgressBar *progressBar;
     QLabel *runIndicator;

--- a/source/gui/simcontrolwidget.h
+++ b/source/gui/simcontrolwidget.h
@@ -40,6 +40,7 @@ private:
     QSpinBox *sbNThreads;
     QSpinBox *sbSeed;
     QSpinBox *sbUpdInterval;
+    QSpinBox *sbMaxTime;
     std::vector<QWidget *> simCtrls;
     std::vector<QLineEdit *> simIndicators;
     QProgressBar *progressBar;


### PR DESCRIPTION
The "Ions to run" spinbox maxes out at INT_MAX (~2.1B). Load a config with `max_no_ions = 5000000000` and it silently stores garbage. Type mismatch between int setter and size_t storage.

The config has `max_cpu_time` and the engine uses it, but there's no GUI field. Users have to edit JSON by hand.

This PR lifts the ion ceiling to 2^53 and adds a "Max CPU time (s)" spinbox.

---

## Changes

- Replace QSpinBox to QDoubleSpinBox (range [1, 2^53])
- Fix setMaxIons: int to quint64 with clamp at source
- Route setOptions() through setMaxIons() so JSON load is also clamped
- Define kMaxExactIons constant once, reference from both widget and driver
- Add sbMaxTime spinbox (0 = "no limit", suffix "s", step 60s)
- Wire max_cpu_time through all 6 paths in mcdriverobj.cpp
- Disable both controls while sim running; re-enable on stop
- Label as "Max CPU time (s)" engine uses CPU time, not wall time

---

**Note:** Ion count capped at 2^53. `QDoubleSpinBox` uses double internally, values above 2^53 lose integer precision. Full quint64 range needs a custom text input widget.

---

## Tested

**Ion count**

| Test | Result |
|---|---|
| Fresh load shows 100 | ✅ |
| Load 5B ions in JSON displays 5000000000 | ✅ |
| Load 1e16 ions clamps to 9007199254740992 | ✅ |
| Type 2^53 + 1 clamps down to 2^53 | ✅ |
| Spinbox disabled while running, re-enables on stop | ✅ |
| Revert on config load restores correct value | ✅ |

**CPU time**

| Test | Result |
|---|---|
| Fresh load shows "no limit" | ✅ |
| Set 120 shows "120 s" | ✅ |
| Set 0 shows "no limit" | ✅ |
| Set 10s with 4 threads stops at 2.5s wall time | ✅ |
| Set 10s with 1 thread stops at 10s wall time | ✅ |
| Disabled while running, re-enables on stop | ✅ |
| Save JSON writes Run.max_cpu_time correctly | ✅ |
| Reload JSON restores Max CPU time correctly | ✅ |

---

Closes TODO: "set limit on ion histories or time to run"