### PR TITLE
Added Contextual Help Panel to Configuration options in OpenTRIM GUI

### DIFF
--- a/source/gui/CMakeLists.txt
+++ b/source/gui/CMakeLists.txt
@@ -22,6 +22,7 @@ set(GUI_HEADERS
     jsedit/jsedit.h 
     simboxview.h
     mcplotinfo.h
+    helppanel.h
 )
 
 set(GUI_SOURCES
@@ -43,6 +44,7 @@ set(GUI_SOURCES
     jsedit/jsedit.cpp
     simboxview.cpp
     mcplotinfo.cpp
+    helppanel.cpp
 )
 
 set (GUI_TARGET ${PROJECT_NAME_LOWERCASE}-gui)

--- a/source/gui/helppanel.cpp
+++ b/source/gui/helppanel.cpp
@@ -1,0 +1,784 @@
+#include "helppanel.h"
+#include "optionsmodel.h"
+
+#include <QTextBrowser>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QEvent>
+#include <QRegularExpression>
+#include <QCheckBox>
+#include <QSpinBox>
+#include <QDoubleSpinBox>
+#include <QComboBox>
+#include <QLineEdit>
+
+/*Help Database*/
+
+void HelpPanel::buildHelpDatabase(){
+    //General simulation options
+
+    helpDb_["simulation_type"] = {
+        "Defines which particles are explicitly transported.",
+        "Use <b>FullCascade</b> for radiation damage studies. "
+        "Use <b>IonsOnly</b> for fast ion range/energy-loss profiles.",
+        "", "FullCascade"
+    };
+
+    helpDb_["screening_type"] = {
+        "The screened Coulomb potential used for calculating nuclear scattering angles. "
+        "This determines the ion-atom interaction physics.",
+        "<b>ZBL</b> is the common default and is compatible with standard SRIM-style screened nuclear scattering assumptions. ",
+        "", "ZBL"
+    };
+
+    helpDb_["electronic_stopping"] = {
+        "Model for continuous energy loss of moving particles to target electrons. "
+        "This is the dominant energy loss mechanism at high velocities.",
+        "Use <b>SRIM13</b> for best agreement with experimental data. ",
+        "", "SRIM13"
+    };
+
+    helpDb_["electronic_straggling"] = {
+        "Statistical fluctuations (straggling) in electronic energy loss. "
+        "Adds realistic broadening to ion range distributions.",
+        "Enable for realistic range distributions. "
+        "Disable for faster runs when only mean ranges are needed.",
+        "", "Off"
+    };
+
+    helpDb_["nrt_calculation"] = {
+        "Method for estimating the number of displacements produced in a collision cascade. ",
+        "The NRT model is the standard for radiation damage estimation. "
+        "Different sub-models handle multi-element targets differently.",
+        "", "NRT_element"
+    };
+
+    helpDb_["intra_cascade_recombination"] = {
+        "Controls whether Frenkel pair recombination within a single collision cascade is modeled. "
+        "In reality, many displaced atoms recombine with nearby vacancies during cascade evolution",
+        "Enable for more realistic defect counts. "
+        "Enabling this option can reduce the number of surviving defects relative to pure NRT-style estimates",
+        "", "false"
+    };
+
+    //Ion transport options
+
+    helpDb_["min_energy"] = {
+        "Minimum kinetic energy (in eV) below which a particle is no longer tracked. "
+        "Lowering this value tracks particles to lower energies — more accurate but slower.",
+        "For sputtering: use 1 eV or lower. "
+        "For deep implant profiles: 5–10 eV is usually sufficient. ",
+        "eV", "1.0"
+    };
+
+    helpDb_["flight_path_type"] = {
+        "How the free flight path (distance between collisions) is determined. "
+        "This determines how collision distances are sampled. ",
+        "<b>Constant</b> uses a fixed mean free path. "
+        "<b>Variable</b> uses energy-dependent mean-free-path tables and may skip low impact scattering events ,below energy or angle thresholds.",
+        "", "Constant"
+    };
+
+    helpDb_["flight_path_const"] = {
+        "The constant free flight path expressed in units of the atomic radius. "
+        "A value of 1.0 corresponds to roughly one collision per atomic spacing.",
+        "Values around 1.0 are standard. Smaller values increase accuracy but slow down the simulation. "
+        "Values much larger than 1 may miss important close collisions.",
+        "× atomic radius", "1.0"
+    };
+
+    helpDb_["max_rel_loss"] = {
+        "Maximum fractional energy loss (ΔE/E) allowed per collision step. "
+        "If a step would lose more than this fraction, the step is shortened.",
+        "Smaller values give more accurate energy loss tracking at the cost of speed. "
+        "The default 0.05 (5%) is a good balance.",
+        "", "0.05"
+    };
+
+    helpDb_["min_recoil_energy"] = {
+        "Minimum energy (in eV) for a recoil atom to be followed as a new cascade particle. "
+        "Recoils below this energy are not tracked and contribute only to local energy deposition.",
+        "Lower values track more recoils (more accurate damage profiles, slower). "
+        "Should be ≤ the displacement energy for accurate defect counting.",
+        "eV", "1.0"
+    };
+
+    helpDb_["min_scattering_angle"] = {
+        "Minimum lab-frame scattering angle considered in variable-flight-path sampling. "
+        "Very small-angle events below this threshold may be ignored for efficiency.",
+        "The default 2° skips very small angle deflections. "
+        "Reduce to 0.5° only if you need extreme accuracy in angular distributions.",
+        "degrees", "2.0"
+    };
+
+
+    //Ion Source
+
+    helpDb_["atomic_number"] = {
+        "Atomic number of the incident ion. Determines the nuclear charge, affecting "
+        " scattering cross-sections and electronic stopping power.",
+        "Common ions: H(1), He(2), C(6), N(7), O(8), Ne(10), Si(14), Ar(18), Kr(36), Xe(54), Au(79).",
+        "", ""
+    };
+
+    helpDb_["atomic_mass"] = {
+        "Atomic mass of the incident ion (amu). "
+        "If set to 0, the natural isotopic average mass is used automatically.",
+        "Set explicitly for specific isotopes (D=2.014, ³He=3.016). "
+        "Leave at 0 for the natural average.",
+        "amu", "0 (natural)"
+    };
+
+     helpDb_["center"] = {
+        "Center value of this distribution. "
+        "For energy: the mean ion beam energy in eV. "
+        "For spatial: the beam center position [x, y, z] in nm. "
+        "For angular: the beam center direction vector.",
+        "Combine with a non-SingleValue distribution type and FWHM to model beam spread.",
+        "", ""
+    };
+
+
+    helpDb_["type"] = {
+        "Type of probability distribution used to sample this parameter. "
+        "<b>SingleValue</b> uses a fixed value (monoenergetic or single directional).",
+        "Use <b>SingleValue</b> for idealized beam conditions. "
+        "Other types add spread around the central value, controlled by the FWHM.",
+        "", "SingleValue"
+    };
+
+
+    helpDb_["fwhm"] = {
+        "Full Width at Half Maximum of the ion position distribution. "
+        "Controls the spread around the central value. "
+        "Only active when the distribution type is not SingleValue.",
+        "Typical beam spot sizes depend on teh system and focusing optics.",
+        "", "1.0"
+    };
+
+    // ── Target ──
+
+    helpDb_["cell_count"] = {
+        "Number of simulation cells along each axis [nx, ny, nz]. "
+        "The z-axis is the depth direction. Defines the spatial resolution of tallied profiles.",
+        "More cells = finer spatial resolution but more memory. "
+        "200–500 depth cells is typical. For 1D simulations, spacial resolution is usually controlled through nz.",
+        "cells", ""
+    };
+
+    helpDb_["origin"] = {
+        "Origin of the simulation grid in nm [x₀, y₀, z₀]. "
+        "Usually [0, 0, 0] — the target surface.",
+        "Adjust if your target does not start at the origin.",
+        "nm", "[0, 0, 0]"
+    };
+
+    helpDb_["size"] = {
+        "Size of the simulation box along each axis [Lx, Ly, Lz] in nm. "
+        "Lz is the target depth. Must be large enough that ions stop inside.",
+        "Use roughly 3× the projected ion range for Lz. "
+        "For 1D simulations, Lx and Ly are irrelevant.",
+        "nm", ""
+    };
+
+    helpDb_["periodic_bc"] = {
+        "Periodic boundary conditions along each axis [x, y, z]. "
+        "A value of 1 enables periodic BC, 0 disables it. "
+        "Periodic BCs wrap particles that exit one side back through the opposite side.",
+        "",
+        "", "[0, 1, 1]"
+    };
+
+    // ── Output options ──
+
+    helpDb_["store_transmitted_ions"] = {
+        "Whether to record particles (ions and atoms) that exit the target. "
+        "Useful for thin-film or foil simulations.",
+        "Enable for transmission experiments or thin targets. "
+        "Disable to save memory for bulk targets.",
+        "", "false"   };
+
+
+    helpDb_["store_damage_events"] = {
+        "Whether to store individual damage events (displacements, replacements, vacancies). "
+        "Provides detailed information about each defect-producing event.",
+        "Enable for detailed damage analysis. "
+        "Can produce large output for high-energy cascades.",
+        "", "false"
+    };
+
+    helpDb_["store_dedx"] = {
+        "Whether to store the depth-resolved energy deposition profile "
+        "(nuclear and electronic components).",
+        "Essential for understanding where energy is dissipated in the target. "
+        "The nuclear component corresponds to lattice damage, the electronic "
+        "component to ionization and excitation.",
+        "", "false"
+    };
+
+    helpDb_["store_exit_events"] = {
+        "Whether to record ions and atoms that exit the target (both transmitted and sputtered). "
+        "Required for computing sputtering yields and transmission data.",
+        "Enable for sputtering studies or thin-film transmission experiments. "
+        "Disable to save memory for bulk targets where only depth profiles are needed.",
+        "", "false"
+    };
+
+    helpDb_["store_pka_events"] = {
+        "Whether to store information about Primary Knock-on Atom (PKA) events. "
+        "PKAs are target atoms initially displaced by the incoming ion, "
+        "initiating a recoil cascade.",
+        "Useful for analyzing PKA energy spectra and damage initiation.",
+        "", "false"
+    };
+
+
+}
+
+/*Style helpers*/
+
+QString HelpPanel::sectionHeader(const QString &title) const{
+    return QString(
+        "<tr>"
+        "  <td style='padding: 6px 0 2px 0; color: #888; font-size: 9pt; "
+        "     text-transform: uppercase; letter-spacing: 1px;'>"
+        "    %1"
+        "  </td>"
+        "</tr>"
+    ).arg(title);
+}
+
+QString HelpPanel::codeBlock(const QString &text) const{
+    return QString(
+        "<code style='background: #f4f4f4; padding: 2px 8px; "
+        "border-radius: 3px; font-size: 10pt;'>%1</code>"
+    ).arg(text);
+}
+
+QString HelpPanel::infoBox(const QString &text, const QString &color) const{
+    return QString(
+        "<div style='background: %2; border-radius: 4px; "
+        "padding: 8px 10px; margin: 4px 0;'>%1</div>"
+    ).arg(text, color);
+}
+
+QString HelpPanel::typeBadge(const QString &typeName) const{
+    return QString(
+        "<span style='background: #e0e7ff; color: #3b5998; font-size: 8pt; "
+        "padding: 2px 8px; border-radius: 8px; font-weight: bold; "
+        "text-transform: uppercase; letter-spacing: 0.5px;'>%1</span>"
+    ).arg(typeName);
+}
+
+QString HelpPanel::effectRow(const QString &value, const QString &desc, const QString &color) const{
+    return QString(
+        "<div style='background: %3; border-radius: 4px; "
+        "padding: 6px 10px; margin-bottom: 3px;'>"
+        "  <code style='font-weight: bold;'>%1</code>"
+        "  <span style='color: #555;'> — %2</span>"
+        "</div>"
+    ).arg(value, desc, color);
+}
+
+/*Text parsing*/
+
+QString HelpPanel::extractMeaning(const QString &text) const{
+    if(text.isEmpty()) return QString();
+
+    int listStart = -1;
+
+    QRegularExpression listPattern(R"([\n\r]\s*-\s+\w)");
+    auto match = listPattern.match(text);
+    if(match.hasMatch()) listStart = match.capturedStart();
+
+    QString meaning;
+    if(listStart >0){
+        meaning = text.left(listStart).trimmed();
+    }else{
+        QRegularExpression sentenceEnd(R"(\.\s)");
+        auto m = sentenceEnd.match(text);
+        if(m.hasMatch()){
+            meaning = text.left(m.capturedStart() +1).trimmed();
+        }else{
+            meaning = text.trimmed();
+        }
+    }
+
+    return meaning;
+}
+
+QStringList HelpPanel::extractOptions(const QString &text) const{
+    QStringList options;
+    if(text.isEmpty())return options;
+
+    QRegularExpression optPattern(R"(-\s+(\w[\w\s]*?)[\s]*[:\-\x{2013}\x{2014}]\s*(.+))");
+    auto it = optPattern.globalMatch(text);
+    while(it.hasNext()){
+        auto match =it.next();
+        QString name = match.captured(1).trimmed();
+        QString desc = match.captured(2).trimmed();
+        options << name + "|" +desc;
+    }
+
+    return options;
+}
+
+QString HelpPanel::parseOptionsListHtml(const QString &text) const{
+    QStringList options = extractOptions(text);
+    if(options.isEmpty()) return QString();
+
+    QString html;
+    html += "<table cellspacing='0' cellpadding='0' style='margin: 4px 0;'>";
+
+    for(const QString &opt : options){
+        QStringList parts = opt.split('|',Qt::KeepEmptyParts);
+        QString name = parts.value(0);
+        QString desc = parts.value(1);
+
+        html += QString(
+            "<tr>"
+            "  <td style='padding: 4px 0;'>"
+            "    <div style='background: #f0f4f8; border-radius: 4px; "
+            "         padding: 6px 10px; margin-bottom: 2px;'>"
+            "      <span style='font-weight: bold; color: #2060a0;'>%1</span>"
+            "      <span style='color: #555;'> — %2</span>"
+            "    </div>"
+            "  </td>"
+            "</tr>"
+        ).arg(name, desc);
+    }
+
+    html += "</table>";
+    return html;
+}
+
+/*Type-specific info*/
+
+QString HelpPanel::booleanEffectHtml(OptionsItem *item) const{
+    QString name = item->name().toLower();
+    QString key = item->key().toLower();
+    QString whats = item->whatsThis();
+    QString desc = whats.isEmpty() ? item->toolTip() : whats;
+
+    //check helpDb for richer description
+    if(helpDb_.contains(item->key())) desc =helpDb_[item->key()].description;
+
+    QString trueEffect, falseEffect;
+
+    if(name.contains("enable") || key.contains("enable")){
+        QString feature = name;
+        feature.remove(QRegularExpression("^enable[sd]?\\s*", QRegularExpression::CaseInsensitiveOption));
+
+        if (feature.isEmpty()) feature = "this feature";
+        
+        trueEffect =QString("Enables %1").arg(feature);
+        falseEffect = QString("Disables %1").arg(feature);
+    }else if(!desc.isEmpty()){
+        QString cleanDesc = desc.trimmed();
+        
+        cleanDesc.remove(QRegularExpression("<[^>]*>")); // Strip HTML tags for the effect row
+        if (cleanDesc.endsWith('.')) cleanDesc.chop(1);
+
+        QRegularExpression firstSentence(R"(^(.+?\.)\s)");  // Take just the first sentence for the effect
+        auto m = firstSentence.match(cleanDesc);
+
+        if(m.hasMatch()){
+            cleanDesc = m.captured(1);
+            if(cleanDesc.endsWith('.'))cleanDesc.chop(1);
+        }
+
+        if(cleanDesc.startsWith("Enable", Qt::CaseInsensitive) ||
+            cleanDesc.startsWith("Control", Qt::CaseInsensitive)){
+            trueEffect = cleanDesc;
+            falseEffect = cleanDesc;
+            if(cleanDesc.startsWith("Enable", Qt::CaseInsensitive))
+                falseEffect.replace(QRegularExpression("^Enable[s]?", QRegularExpression::CaseInsensitiveOption), "Disable");
+            else if(cleanDesc.startsWith("Control", Qt::CaseInsensitive))
+                falseEffect.replace(QRegularExpression("^Controls", QRegularExpression::CaseInsensitiveOption), "Disables");
+        }else if(cleanDesc.startsWith("Whether",Qt::CaseInsensitive)){
+            QString action = cleanDesc;
+
+            action.remove(QRegularExpression("^Whether\\s+(to\\s+)?", QRegularExpression::CaseInsensitiveOption));
+
+            QString capitalized = action.left(1).toUpper() +action.mid(1);
+            trueEffect = capitalized;
+            falseEffect = QString("Does NOT %1").arg(action);
+        }else{
+            trueEffect = cleanDesc;
+            falseEffect = QString("Disables %1").arg(cleanDesc.left(1).toLower() + cleanDesc.mid(1));
+        }
+    }else{
+        QString label = item->name().isEmpty() ? item->key() : item->name();
+        trueEffect = QString("Enables %1").arg(label.toLower());
+        falseEffect = QString("Disables %1").arg(label.toLower());
+    }
+
+    QString html;
+    html += effectRow("true", trueEffect, "#e8f5e9");
+    html += effectRow("false", falseEffect, "#fce4ec");
+    return html;
+}
+
+QString HelpPanel::typeInfoHtml(OptionsItem *item) const{
+    QVariant val = item->value();
+    QString html;
+
+    for(auto it = widgetIndexMap_.constBegin(); it !=widgetIndexMap_.constEnd(); ++it){
+        if(!it.value().isValid()) continue;
+        OptionsItem *mappedItem = static_cast<OptionsItem *>(it.value().internalPointer());
+        if(mappedItem != item)continue;
+
+        QWidget *widget = it.key();
+
+        /*boolean box*/
+        QComboBox *combo = qobject_cast<QComboBox *>(widget);
+        if (combo && combo->count() == 2) {
+            QString item0 = combo->itemText(0).toLower();
+            QString item1 = combo->itemText(1).toLower();
+            if ((item0 =="false" && item1 == "true") ||
+                (item0== "true" && item1 == "false")) {
+                html += sectionHeader("Type");
+                html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
+                            .arg(typeBadge("Boolean"));
+                html += sectionHeader("Effect");
+                html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
+                            .arg(booleanEffectHtml(item));
+                return html;
+            }
+        }
+
+        /*enum combo box*/
+        if(combo && combo->count() > 0){
+            html += sectionHeader("Type");
+            html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
+                        .arg(typeBadge("Selection"));
+
+            QString whats = item->whatsThis();
+            QStringList parsed = extractOptions(whats.isEmpty() ? item->toolTip() : whats);
+            if(parsed.isEmpty()){
+                html += sectionHeader("Options");
+                QString optsHtml;
+                for(int i = 0; i < combo->count(); ++i){
+                    QString tipText = combo->itemData(i, Qt::ToolTipRole).toString();
+                    if (tipText.isEmpty()) tipText = combo->itemText(i);
+                    optsHtml += effectRow(combo->itemText(i), tipText, (i % 2 == 0) ? "#f0f4f8" : "#e8ecf0");
+                }
+                html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>").arg(optsHtml);
+            }
+            return html;
+        }
+
+        /*checkbox*/
+        QCheckBox *check = qobject_cast<QCheckBox *>(widget);
+        if(check){
+            html += sectionHeader("Type");
+            html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
+                        .arg(typeBadge("Boolean"));
+            html += sectionHeader("Effect");
+            html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
+                        .arg(booleanEffectHtml(item));
+            return html;
+        }
+
+        /*spinbox*/
+        QSpinBox *spin = qobject_cast<QSpinBox *>(widget);
+        if (spin) {
+            html += sectionHeader("Type");
+            html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
+                        .arg(typeBadge("Integer"));
+            QString rangeStr = QString("%1 – %2")
+                .arg(spin->minimum()).arg(spin->maximum());
+            html += sectionHeader("Range");
+            html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
+                        .arg(codeBlock(rangeStr));
+            return html;
+        }
+
+        QDoubleSpinBox *dspin = qobject_cast<QDoubleSpinBox *>(widget);
+        if(dspin){
+            html += sectionHeader("Type");
+            html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
+                        .arg(typeBadge("Float"));
+            QString rangeStr = QString("%1 – %2")
+                .arg(dspin->minimum(), 0, 'g', 6)
+                .arg(dspin->maximum(), 0, 'g', 6);
+            html += sectionHeader("Range");
+            html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
+                        .arg(codeBlock(rangeStr));
+            if (!qFuzzyIsNull(dspin->singleStep())) {
+                html += sectionHeader("Step size");
+                html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
+                            .arg(codeBlock(QString::number(dspin->singleStep(), 'g', 6)));
+            }
+            return html;
+        }
+
+        //detect numeric vs text
+        QLineEdit *le = qobject_cast<QLineEdit *>(widget);
+        if(le){
+            bool isNumeric = false;
+            QString valStr = val.toString().trimmed();
+            if(!valStr.isEmpty()){
+                valStr.toDouble(&isNumeric);
+                if(!isNumeric && valStr.startsWith('[') && valStr.endsWith(']')){
+                    html += sectionHeader("Type");
+                    html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
+                                .arg(typeBadge("Array"));
+                    html += sectionHeader("Format");
+                    html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
+                                .arg(codeBlock("[x, y, z]"));
+                    return html;
+                }
+            }
+            html += sectionHeader("Type");
+            html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
+                        .arg(typeBadge(isNumeric ? "Float" : "Text"));
+            return html;
+        }
+
+        break;
+    }
+
+    //fallback
+    switch (static_cast<QMetaType::Type>(val.type())){
+    case QMetaType::Bool:
+        html += sectionHeader("Type");
+        html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
+                    .arg(typeBadge("Boolean"));
+        html += sectionHeader("Effect");
+        html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
+                    .arg(booleanEffectHtml(item));
+        break;
+    case QMetaType::Int:
+    case QMetaType::LongLong:
+        html += sectionHeader("Type");
+        html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
+                    .arg(typeBadge("Integer"));
+        break;
+    case QMetaType::Double:
+    case QMetaType::Float:
+        html += sectionHeader("Type");
+        html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
+                    .arg(typeBadge("Float"));
+        break;
+    default:
+        break;
+    }
+
+    return html;
+}
+
+/*Constructor and Widget Registration*/
+
+HelpPanel::HelpPanel(OptionsModel *model, QWidget *parent): QWidget(parent), model_(model){
+    setObjectName("HelpPanel");
+    setMinimumWidth(250);
+    setMaximumWidth(380);
+
+    buildHelpDatabase();
+
+    QVBoxLayout *layout = new QVBoxLayout(this);
+    layout->setContentsMargins(4, 4, 4, 4);
+
+    QHBoxLayout *header = new QHBoxLayout;
+
+    QLabel *title = new QLabel("<b>Config Help</b>");
+
+    QPushButton *closeBtn = new QPushButton(QString::fromUtf8("\xc3\x97"));
+    closeBtn->setFixedSize(24, 24);
+    closeBtn->setFlat(true);
+    connect(closeBtn, &QPushButton::clicked, this, &HelpPanel::toggleVisibility);
+    
+    header->addWidget(title);
+    header->addStretch();
+    header->addWidget(closeBtn);
+    
+    layout->addLayout(header);
+
+    browser_ = new QTextBrowser;
+    browser_->setOpenExternalLinks(false);
+    browser_->setReadOnly(true);
+    browser_->setStyleSheet(
+        "QTextBrowser {"
+        "  font-size: 10pt;"
+        "  padding: 4px;"
+        "  border: 1px solid #d0d0d0;"
+        "  border-radius: 4px;"
+        "  background: #fafafa;"
+        "}"
+    );
+    layout->addWidget(browser_);
+
+    clear();
+}
+
+void HelpPanel::registerWidget(QWidget *editor, const QModelIndex &index){
+    if(!editor || !index.isValid()) return;
+
+    widgetIndexMap_.insert(editor, QPersistentModelIndex(index));
+    editor->setMouseTracking(true);
+    editor->setAttribute(Qt::WA_Hover, true);
+    editor->installEventFilter(this);
+}
+
+bool HelpPanel::eventFilter(QObject *watched, QEvent *event){
+    if(event->type() == QEvent::FocusIn ||
+        event->type() == QEvent::Enter ||
+        event->type() == QEvent::HoverEnter) {
+        QWidget *w = qobject_cast<QWidget *>(watched);
+        if(w && widgetIndexMap_.contains(w)){
+            showHelpFor(widgetIndexMap_.value(w));
+            return false;
+        }
+    }
+    return QWidget::eventFilter(watched, event);
+}
+
+void HelpPanel::toggleVisibility(){
+    setVisible(!isVisible());
+}
+
+void HelpPanel::showHelpFor(const QModelIndex &index){
+    if(!index.isValid()){
+        clear();
+        return;
+    }
+
+    OptionsItem *item = static_cast<OptionsItem *>(index.internalPointer());
+    if(!item){
+        clear();
+        return;
+    }
+
+    browser_->setHtml(generateHelpHtml(item));
+}
+
+void HelpPanel::clear(){
+    browser_->setHtml("<html><body style='color: #999; padding: 20px; text-align: center;'>"
+        "<p style='font-size: 14pt;'></p>"
+        "<p><i>Hover over a configuration option<br/>to see its description.</i></p>"
+        "</body></html>"
+    );
+}
+
+// Main HTML generation
+
+QString HelpPanel::generateHelpHtml(OptionsItem *item) const{
+    QString key = item->key();
+
+    bool hasDbEntry = helpDb_.contains(key);
+
+    HelpEntry entry;
+    if(hasDbEntry) entry = helpDb_.value(key);
+
+    QString html;
+    html += "<html><body style='padding: 6px; font-family: sans-serif; "
+            "line-height: 1.4; color: #333;'>";
+
+    /*Title*/
+    QString name = item->name().isEmpty() ? key : item->name();
+    html += QString("<div style='border-bottom: 2px solid #2060a0; padding-bottom: 6px; "
+        "margin-bottom: 8px;'>"
+        "  <span style='font-size: 14pt; font-weight: bold; color: #2060a0;'>%1</span>"
+        "</div>"
+    ).arg(name);
+
+    html += "<table width='100%' cellspacing='0' cellpadding='0'>";
+
+    /*Internal name*/
+    if(!key.isEmpty()){
+        html += sectionHeader("Internal name");
+        html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>").arg(codeBlock(key));
+    }
+
+    /*Description, prefer helpDb, fall back to whatsThis/toolTip*/
+    QString whats = item->whatsThis();
+    QString tip = item->toolTip();
+    QString descText;
+
+    if(hasDbEntry && !entry.description.isEmpty()){
+        descText = entry.description;
+    }else{
+        descText = whats.isEmpty() ? tip : whats;
+    }
+
+    QString meaning = extractMeaning(descText);
+    if(!meaning.isEmpty()){
+        html += sectionHeader("Description");
+        html += QString("<tr><td style='padding: 2px 0 10px 0;'>"
+            "  <span style='font-size: 10pt;'>%1</span>"
+            "</td></tr>").arg(hasDbEntry ? descText : meaning);
+    }
+
+    if(hasDbEntry && !entry.units.isEmpty()){
+        html += sectionHeader("Units");
+        html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>").arg(typeBadge(entry.units));
+    }
+
+    QString typeHtml = typeInfoHtml(item);
+    bool isSelectionType = typeHtml.contains("SELECTION", Qt::CaseInsensitive);
+    html += typeHtml;
+
+    if(isSelectionType){
+        QString meaningSource = whats.isEmpty() ? tip : whats;
+        QString optionsHtml = parseOptionsListHtml(meaningSource);
+
+        if(!optionsHtml.isEmpty()){
+            html += sectionHeader("Options");
+            html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>").arg(optionsHtml);
+        }
+    }
+
+    if(hasDbEntry && !entry.tip.isEmpty()){
+        html += sectionHeader("Tip");
+        html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>").arg(infoBox(entry.tip,"#fff8e1"));
+    }
+
+    if(!hasDbEntry && !tip.isEmpty() && tip != whats && tip != meaning){
+        QString tipMeaning = extractMeaning(tip);
+        if(tipMeaning != meaning && !tipMeaning.isEmpty()){
+            html += sectionHeader("Note");
+            html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>"
+            ).arg(infoBox(tipMeaning, "#fff8e1"));
+        }
+    }
+
+    QVariant val = item->value();
+    if(val.isValid() && !val.isNull()){
+        html += sectionHeader("Current value");
+
+        QString valStr = val.toString();
+        QString bg = "#f4f4f4";
+
+        if(static_cast<QMetaType::Type>(val.type()) == QMetaType::Bool){
+            bg = val.toBool() ? "#e8f5e9" : "#fce4ec";
+            valStr = val.toBool() ? "true" : "false";
+        }else if (valStr.toLower() == "true"){
+            bg = "#e8f5e9";
+        }else if (valStr.toLower() == "false"){
+            bg = "#fce4ec";
+        }
+
+        html += QString("<tr><td style='padding: 2px 0 10px 0;'>"
+            "  <code style='background: %2; padding: 2px 8px; "
+            "  border-radius: 3px; font-size: 10pt; font-weight: bold;'>%1</code>"
+            "</td></tr>"
+        ).arg(valStr, bg);
+    }
+
+
+    /*Group info*/
+    if(item->childCount() > 0){
+        html += sectionHeader("Contents");
+        html += QString("<tr><td style='padding: 2px 0 10px 0; color: #888;'>"
+            "  <i>Group with %1 sub-options</i>"
+            "</td></tr>"
+        ).arg(item->childCount());
+    }
+
+    html += "</table>";
+    html += "</body></html>";
+    return html;
+}

--- a/source/gui/helppanel.cpp
+++ b/source/gui/helppanel.cpp
@@ -760,16 +760,6 @@ QString HelpPanel::generateHelpHtml(OptionsItem *item) const{
         ).arg(valStr, bg);
     }
 
-
-    /*Group info*/
-    if(item->childCount() > 0){
-        html += sectionHeader("Contents");
-        html += QString("<tr><td style='padding: 2px 0 10px 0; color: #888;'>"
-            "  <i>Group with %1 sub-options</i>"
-            "</td></tr>"
-        ).arg(item->childCount());
-    }
-
     html += "</table>";
     html += "</body></html>";
     return html;

--- a/source/gui/helppanel.cpp
+++ b/source/gui/helppanel.cpp
@@ -23,21 +23,21 @@ void HelpPanel::buildHelpDatabase(){
         "Defines which particles are explicitly transported.",
         "Use <b>FullCascade</b> for radiation damage studies. "
         "Use <b>IonsOnly</b> for fast ion range/energy-loss profiles.",
-        "", "FullCascade"
+        ""
     };
 
     helpDb_["screening_type"] = {
         "The screened Coulomb potential used for calculating nuclear scattering angles. "
         "This determines the ion-atom interaction physics.",
         "<b>ZBL</b> is the common default and is compatible with standard SRIM-style screened nuclear scattering assumptions. ",
-        "", "ZBL"
+        ""
     };
 
     helpDb_["electronic_stopping"] = {
         "Model for continuous energy loss of moving particles to target electrons. "
         "This is the dominant energy loss mechanism at high velocities.",
         "Use <b>SRIM13</b> for best agreement with experimental data. ",
-        "", "SRIM13"
+        ""
     };
 
     helpDb_["electronic_straggling"] = {
@@ -45,14 +45,14 @@ void HelpPanel::buildHelpDatabase(){
         "Adds realistic broadening to ion range distributions.",
         "Enable for realistic range distributions. "
         "Disable for faster runs when only mean ranges are needed.",
-        "", "Off"
+        ""
     };
 
     helpDb_["nrt_calculation"] = {
         "Method for estimating the number of displacements produced in a collision cascade. ",
         "The NRT model is the standard for radiation damage estimation. "
         "Different sub-models handle multi-element targets differently.",
-        "", "NRT_element"
+        ""
     };
 
     helpDb_["intra_cascade_recombination"] = {
@@ -60,7 +60,7 @@ void HelpPanel::buildHelpDatabase(){
         "In reality, many displaced atoms recombine with nearby vacancies during cascade evolution",
         "Enable for more realistic defect counts. "
         "Enabling this option can reduce the number of surviving defects relative to pure NRT-style estimates",
-        "", "false"
+        ""
     };
 
     //Ion transport options
@@ -70,7 +70,7 @@ void HelpPanel::buildHelpDatabase(){
         "Lowering this value tracks particles to lower energies — more accurate but slower.",
         "For sputtering: use 1 eV or lower. "
         "For deep implant profiles: 5–10 eV is usually sufficient. ",
-        "eV", "1.0"
+        "eV"
     };
 
     helpDb_["flight_path_type"] = {
@@ -78,7 +78,7 @@ void HelpPanel::buildHelpDatabase(){
         "This determines how collision distances are sampled. ",
         "<b>Constant</b> uses a fixed mean free path. "
         "<b>Variable</b> uses energy-dependent mean-free-path tables and may skip low impact scattering events ,below energy or angle thresholds.",
-        "", "Constant"
+        ""
     };
 
     helpDb_["flight_path_const"] = {
@@ -86,7 +86,7 @@ void HelpPanel::buildHelpDatabase(){
         "A value of 1.0 corresponds to roughly one collision per atomic spacing.",
         "Values around 1.0 are standard. Smaller values increase accuracy but slow down the simulation. "
         "Values much larger than 1 may miss important close collisions.",
-        "× atomic radius", "1.0"
+        "× atomic radius"
     };
 
     helpDb_["max_rel_loss"] = {
@@ -94,7 +94,7 @@ void HelpPanel::buildHelpDatabase(){
         "If a step would lose more than this fraction, the step is shortened.",
         "Smaller values give more accurate energy loss tracking at the cost of speed. "
         "The default 0.05 (5%) is a good balance.",
-        "", "0.05"
+        ""
     };
 
     helpDb_["min_recoil_energy"] = {
@@ -102,7 +102,7 @@ void HelpPanel::buildHelpDatabase(){
         "Recoils below this energy are not tracked and contribute only to local energy deposition.",
         "Lower values track more recoils (more accurate damage profiles, slower). "
         "Should be ≤ the displacement energy for accurate defect counting.",
-        "eV", "1.0"
+        "eV"
     };
 
     helpDb_["min_scattering_angle"] = {
@@ -110,7 +110,7 @@ void HelpPanel::buildHelpDatabase(){
         "Very small-angle events below this threshold may be ignored for efficiency.",
         "The default 2° skips very small angle deflections. "
         "Reduce to 0.5° only if you need extreme accuracy in angular distributions.",
-        "degrees", "2.0"
+        "degrees"
     };
 
 
@@ -120,7 +120,7 @@ void HelpPanel::buildHelpDatabase(){
         "Atomic number of the incident ion. Determines the nuclear charge, affecting "
         " scattering cross-sections and electronic stopping power.",
         "Common ions: H(1), He(2), C(6), N(7), O(8), Ne(10), Si(14), Ar(18), Kr(36), Xe(54), Au(79).",
-        "", ""
+        ""
     };
 
     helpDb_["atomic_mass"] = {
@@ -128,7 +128,7 @@ void HelpPanel::buildHelpDatabase(){
         "If set to 0, the natural isotopic average mass is used automatically.",
         "Set explicitly for specific isotopes (D=2.014, ³He=3.016). "
         "Leave at 0 for the natural average.",
-        "amu", "0 (natural)"
+        "amu"
     };
 
      helpDb_["center"] = {
@@ -137,7 +137,7 @@ void HelpPanel::buildHelpDatabase(){
         "For spatial: the beam center position [x, y, z] in nm. "
         "For angular: the beam center direction vector.",
         "Combine with a non-SingleValue distribution type and FWHM to model beam spread.",
-        "", ""
+        ""
     };
 
 
@@ -146,7 +146,7 @@ void HelpPanel::buildHelpDatabase(){
         "<b>SingleValue</b> uses a fixed value (monoenergetic or single direction).",
         "Use <b>SingleValue</b> for idealized beam conditions. "
         "Other types add spread around the central value, controlled by the FWHM.",
-        "", "SingleValue"
+        ""
     };
 
 
@@ -155,7 +155,7 @@ void HelpPanel::buildHelpDatabase(){
         "Controls the spread around the mean value. "
         "Only active when the distribution type is not SingleValue.",
         "Typical beam spot sizes depend on teh system and focusing optics.",
-        "", "1.0"
+        ""
     };
 
     //Target
@@ -165,14 +165,14 @@ void HelpPanel::buildHelpDatabase(){
         "The z-axis is the depth direction. Defines the spatial resolution of tallied profiles.",
         "More cells = finer spatial resolution but more memory. "
         "200–500 depth cells is typical. For 1D simulations, spacial resolution is usually controlled through nz.",
-        "cells", ""
+        "cells"
     };
 
     helpDb_["origin"] = {
         "Origin of the simulation grid in nm [x₀, y₀, z₀]. "
-        "Usually [0, 0, 0] — the target surface.",
+        "Usually [0, 0, 0], the target surface.",
         "Adjust if your target does not start at the origin.",
-        "nm", "[0, 0, 0]"
+        "nm"
     };
 
     helpDb_["size"] = {
@@ -180,7 +180,7 @@ void HelpPanel::buildHelpDatabase(){
         "Lz is the target depth. Must be large enough that ions stop inside.",
         "Use roughly 3× the projected ion range for Lz. "
         "For 1D simulations, Lx and Ly are irrelevant.",
-        "nm", ""
+        "nm"
     };
 
     helpDb_["periodic_bc"] = {
@@ -188,7 +188,7 @@ void HelpPanel::buildHelpDatabase(){
         "A value of 1 enables periodic BC, 0 disables it. "
         "Periodic BCs wrap particles that exit one side back through the opposite side.",
         "",
-        "", "[0, 1, 1]"
+        ""
     };
 
     //Output options
@@ -198,7 +198,7 @@ void HelpPanel::buildHelpDatabase(){
         "Provides detailed information about each defect-producing event.",
         "Enable for detailed damage analysis. "
         "Can produce large output for high-energy cascades.",
-        "", "false"
+        ""
     };
 
     helpDb_["store_dedx"] = {
@@ -207,7 +207,7 @@ void HelpPanel::buildHelpDatabase(){
         "Essential for understanding where energy is dissipated in the target. "
         "The nuclear component corresponds to lattice damage, the electronic "
         "component to ionization and excitation.",
-        "", "false"
+        ""
     };
 
     helpDb_["store_exit_events"] = {
@@ -215,7 +215,7 @@ void HelpPanel::buildHelpDatabase(){
         "Required for computing sputtering yields and transmission data.",
         "Enable for sputtering studies or thin-film transmission experiments. "
         "Disable to save memory for bulk targets where only depth profiles are needed.",
-        "", "false"
+        ""
     };
 
     helpDb_["store_pka_events"] = {
@@ -223,7 +223,7 @@ void HelpPanel::buildHelpDatabase(){
         "PKAs are target atoms initially displaced by the incoming ion, "
         "initiating a recoil cascade.",
         "Useful for analyzing PKA energy spectra and damage initiation.",
-        "", "false"
+        ""
     };
 
 

--- a/source/gui/helppanel.cpp
+++ b/source/gui/helppanel.cpp
@@ -132,7 +132,7 @@ void HelpPanel::buildHelpDatabase(){
     };
 
      helpDb_["center"] = {
-        "Center value of this distribution. "
+        "Mean value of this distribution. "
         "For energy: the mean ion beam energy in eV. "
         "For spatial: the beam center position [x, y, z] in nm. "
         "For angular: the beam center direction vector.",
@@ -143,7 +143,7 @@ void HelpPanel::buildHelpDatabase(){
 
     helpDb_["type"] = {
         "Type of probability distribution used to sample this parameter. "
-        "<b>SingleValue</b> uses a fixed value (monoenergetic or single directional).",
+        "<b>SingleValue</b> uses a fixed value (monoenergetic or single direction).",
         "Use <b>SingleValue</b> for idealized beam conditions. "
         "Other types add spread around the central value, controlled by the FWHM.",
         "", "SingleValue"
@@ -151,14 +151,14 @@ void HelpPanel::buildHelpDatabase(){
 
 
     helpDb_["fwhm"] = {
-        "Full Width at Half Maximum of the ion position distribution. "
-        "Controls the spread around the central value. "
+        "Full Width at Half Maximum of the distribution. "
+        "Controls the spread around the mean value. "
         "Only active when the distribution type is not SingleValue.",
         "Typical beam spot sizes depend on teh system and focusing optics.",
         "", "1.0"
     };
 
-    // ── Target ──
+    //Target
 
     helpDb_["cell_count"] = {
         "Number of simulation cells along each axis [nx, ny, nz]. "
@@ -191,15 +191,7 @@ void HelpPanel::buildHelpDatabase(){
         "", "[0, 1, 1]"
     };
 
-    // ── Output options ──
-
-    helpDb_["store_transmitted_ions"] = {
-        "Whether to record particles (ions and atoms) that exit the target. "
-        "Useful for thin-film or foil simulations.",
-        "Enable for transmission experiments or thin targets. "
-        "Disable to save memory for bulk targets.",
-        "", "false"   };
-
+    //Output options
 
     helpDb_["store_damage_events"] = {
         "Whether to store individual damage events (displacements, replacements, vacancies). "

--- a/source/gui/helppanel.cpp
+++ b/source/gui/helppanel.cpp
@@ -13,612 +13,260 @@
 #include <QDoubleSpinBox>
 #include <QComboBox>
 #include <QLineEdit>
-
-/*Help Database*/
-
-void HelpPanel::buildHelpDatabase(){
-    //General simulation options
-
-    helpDb_["simulation_type"] = {
-        "Defines which particles are explicitly transported.",
-        "Use <b>FullCascade</b> for radiation damage studies. "
-        "Use <b>IonsOnly</b> for fast ion range/energy-loss profiles.",
-        ""
-    };
-
-    helpDb_["screening_type"] = {
-        "The screened Coulomb potential used for calculating nuclear scattering angles. "
-        "This determines the ion-atom interaction physics.",
-        "<b>ZBL</b> is the common default and is compatible with standard SRIM-style screened nuclear scattering assumptions. ",
-        ""
-    };
-
-    helpDb_["electronic_stopping"] = {
-        "Model for continuous energy loss of moving particles to target electrons. "
-        "This is the dominant energy loss mechanism at high velocities.",
-        "Use <b>SRIM13</b> for best agreement with experimental data. ",
-        ""
-    };
-
-    helpDb_["electronic_straggling"] = {
-        "Statistical fluctuations (straggling) in electronic energy loss. "
-        "Adds realistic broadening to ion range distributions.",
-        "Enable for realistic range distributions. "
-        "Disable for faster runs when only mean ranges are needed.",
-        ""
-    };
-
-    helpDb_["nrt_calculation"] = {
-        "Method for estimating the number of displacements produced in a collision cascade. ",
-        "The NRT model is the standard for radiation damage estimation. "
-        "Different sub-models handle multi-element targets differently.",
-        ""
-    };
-
-    helpDb_["intra_cascade_recombination"] = {
-        "Controls whether Frenkel pair recombination within a single collision cascade is modeled. "
-        "In reality, many displaced atoms recombine with nearby vacancies during cascade evolution",
-        "Enable for more realistic defect counts. "
-        "Enabling this option can reduce the number of surviving defects relative to pure NRT-style estimates",
-        ""
-    };
-
-    //Ion transport options
-
-    helpDb_["min_energy"] = {
-        "Minimum kinetic energy (in eV) below which a particle is no longer tracked. "
-        "Lowering this value tracks particles to lower energies — more accurate but slower.",
-        "For sputtering: use 1 eV or lower. "
-        "For deep implant profiles: 5–10 eV is usually sufficient. ",
-        "eV"
-    };
-
-    helpDb_["flight_path_type"] = {
-        "How the free flight path (distance between collisions) is determined. "
-        "This determines how collision distances are sampled. ",
-        "<b>Constant</b> uses a fixed mean free path. "
-        "<b>Variable</b> uses energy-dependent mean-free-path tables and may skip low impact scattering events ,below energy or angle thresholds.",
-        ""
-    };
-
-    helpDb_["flight_path_const"] = {
-        "The constant free flight path expressed in units of the atomic radius. "
-        "A value of 1.0 corresponds to roughly one collision per atomic spacing.",
-        "Values around 1.0 are standard. Smaller values increase accuracy but slow down the simulation. "
-        "Values much larger than 1 may miss important close collisions.",
-        "× atomic radius"
-    };
-
-    helpDb_["max_rel_loss"] = {
-        "Maximum fractional energy loss (ΔE/E) allowed per collision step. "
-        "If a step would lose more than this fraction, the step is shortened.",
-        "Smaller values give more accurate energy loss tracking at the cost of speed. "
-        "The default 0.05 (5%) is a good balance.",
-        ""
-    };
-
-    helpDb_["min_recoil_energy"] = {
-        "Minimum energy (in eV) for a recoil atom to be followed as a new cascade particle. "
-        "Recoils below this energy are not tracked and contribute only to local energy deposition.",
-        "Lower values track more recoils (more accurate damage profiles, slower). "
-        "Should be ≤ the displacement energy for accurate defect counting.",
-        "eV"
-    };
-
-    helpDb_["min_scattering_angle"] = {
-        "Minimum lab-frame scattering angle considered in variable-flight-path sampling. "
-        "Very small-angle events below this threshold may be ignored for efficiency.",
-        "The default 2° skips very small angle deflections. "
-        "Reduce to 0.5° only if you need extreme accuracy in angular distributions.",
-        "degrees"
-    };
-
-
-    //Ion Source
-
-    helpDb_["atomic_number"] = {
-        "Atomic number of the incident ion. Determines the nuclear charge, affecting "
-        " scattering cross-sections and electronic stopping power.",
-        "Common ions: H(1), He(2), C(6), N(7), O(8), Ne(10), Si(14), Ar(18), Kr(36), Xe(54), Au(79).",
-        ""
-    };
-
-    helpDb_["atomic_mass"] = {
-        "Atomic mass of the incident ion (amu). "
-        "If set to 0, the natural isotopic average mass is used automatically.",
-        "Set explicitly for specific isotopes (D=2.014, ³He=3.016). "
-        "Leave at 0 for the natural average.",
-        "amu"
-    };
-
-     helpDb_["center"] = {
-        "Mean value of this distribution. "
-        "For energy: the mean ion beam energy in eV. "
-        "For spatial: the beam center position [x, y, z] in nm. "
-        "For angular: the beam center direction vector.",
-        "Combine with a non-SingleValue distribution type and FWHM to model beam spread.",
-        ""
-    };
-
-
-    helpDb_["type"] = {
-        "Type of probability distribution used to sample this parameter. "
-        "<b>SingleValue</b> uses a fixed value (monoenergetic or single direction).",
-        "Use <b>SingleValue</b> for idealized beam conditions. "
-        "Other types add spread around the central value, controlled by the FWHM.",
-        ""
-    };
-
-
-    helpDb_["fwhm"] = {
-        "Full Width at Half Maximum of the distribution. "
-        "Controls the spread around the mean value. "
-        "Only active when the distribution type is not SingleValue.",
-        "Typical beam spot sizes depend on teh system and focusing optics.",
-        ""
-    };
-
-    //Target
-
-    helpDb_["cell_count"] = {
-        "Number of simulation cells along each axis [nx, ny, nz]. "
-        "The z-axis is the depth direction. Defines the spatial resolution of tallied profiles.",
-        "More cells = finer spatial resolution but more memory. "
-        "200–500 depth cells is typical. For 1D simulations, spacial resolution is usually controlled through nz.",
-        "cells"
-    };
-
-    helpDb_["origin"] = {
-        "Origin of the simulation grid in nm [x₀, y₀, z₀]. "
-        "Usually [0, 0, 0], the target surface.",
-        "Adjust if your target does not start at the origin.",
-        "nm"
-    };
-
-    helpDb_["size"] = {
-        "Size of the simulation box along each axis [Lx, Ly, Lz] in nm. "
-        "Lz is the target depth. Must be large enough that ions stop inside.",
-        "Use roughly 3× the projected ion range for Lz. "
-        "For 1D simulations, Lx and Ly are irrelevant.",
-        "nm"
-    };
-
-    helpDb_["periodic_bc"] = {
-        "Periodic boundary conditions along each axis [x, y, z]. "
-        "A value of 1 enables periodic BC, 0 disables it. "
-        "Periodic BCs wrap particles that exit one side back through the opposite side.",
-        "",
-        ""
-    };
-
-    //Output options
-
-    helpDb_["store_damage_events"] = {
-        "Whether to store individual damage events (displacements, replacements, vacancies). "
-        "Provides detailed information about each defect-producing event.",
-        "Enable for detailed damage analysis. "
-        "Can produce large output for high-energy cascades.",
-        ""
-    };
-
-    helpDb_["store_dedx"] = {
-        "Whether to store the depth-resolved energy deposition profile "
-        "(nuclear and electronic components).",
-        "Essential for understanding where energy is dissipated in the target. "
-        "The nuclear component corresponds to lattice damage, the electronic "
-        "component to ionization and excitation.",
-        ""
-    };
-
-    helpDb_["store_exit_events"] = {
-        "Whether to record ions and atoms that exit the target (both transmitted and sputtered). "
-        "Required for computing sputtering yields and transmission data.",
-        "Enable for sputtering studies or thin-film transmission experiments. "
-        "Disable to save memory for bulk targets where only depth profiles are needed.",
-        ""
-    };
-
-    helpDb_["store_pka_events"] = {
-        "Whether to store information about Primary Knock-on Atom (PKA) events. "
-        "PKAs are target atoms initially displaced by the incoming ion, "
-        "initiating a recoil cascade.",
-        "Useful for analyzing PKA energy spectra and damage initiation.",
-        ""
-    };
-
-
-}
-
-/*Style helpers*/
+#include <QSplitter>
 
 QString HelpPanel::sectionHeader(const QString &title) const{
-    return QString(
-        "<tr>"
-        "  <td style='padding: 6px 0 2px 0; color: #888; font-size: 9pt; "
-        "     text-transform: uppercase; letter-spacing: 1px;'>"
-        "    %1"
-        "  </td>"
-        "</tr>"
+    return QString("<tr><td style='padding: 8px 0 2px 0;'>"
+        "  <span style='font-size: 8pt; font-weight: bold; "
+        "  text-transform: uppercase; color: #888; "
+        "  letter-spacing: 1px;'>%1</span>"
+        "</td></tr>"
     ).arg(title);
 }
 
-QString HelpPanel::codeBlock(const QString &text) const{
-    return QString(
-        "<code style='background: #f4f4f4; padding: 2px 8px; "
-        "border-radius: 3px; font-size: 10pt;'>%1</code>"
-    ).arg(text);
+
+QString HelpPanel::detectCurrentValue(OptionsItem *item) const{
+    if(!item) return QString();
+
+    QVariant val = item->value();
+    return val.isValid() ? val.toString() : QString();
 }
 
-QString HelpPanel::infoBox(const QString &text, const QString &color) const{
-    return QString(
-        "<div style='background: %2; border-radius: 4px; "
-        "padding: 8px 10px; margin: 4px 0;'>%1</div>"
-    ).arg(text, color);
-}
 
-QString HelpPanel::typeBadge(const QString &typeName) const{
-    return QString(
-        "<span style='background: #e0e7ff; color: #3b5998; font-size: 8pt; "
-        "padding: 2px 8px; border-radius: 8px; font-weight: bold; "
-        "text-transform: uppercase; letter-spacing: 0.5px;'>%1</span>"
-    ).arg(typeName);
-}
-
-QString HelpPanel::effectRow(const QString &value, const QString &desc, const QString &color) const{
-    return QString(
-        "<div style='background: %3; border-radius: 4px; "
-        "padding: 6px 10px; margin-bottom: 3px;'>"
-        "  <code style='font-weight: bold;'>%1</code>"
-        "  <span style='color: #555;'> — %2</span>"
-        "</div>"
-    ).arg(value, desc, color);
-}
-
-/*Text parsing*/
-
-QString HelpPanel::extractMeaning(const QString &text) const{
-    if(text.isEmpty()) return QString();
-
-    int listStart = -1;
-
-    QRegularExpression listPattern(R"([\n\r]\s*-\s+\w)");
-    auto match = listPattern.match(text);
-    if(match.hasMatch()) listStart = match.capturedStart();
-
-    QString meaning;
-    if(listStart >0){
-        meaning = text.left(listStart).trimmed();
-    }else{
-        QRegularExpression sentenceEnd(R"(\.\s)");
-        auto m = sentenceEnd.match(text);
-        if(m.hasMatch()){
-            meaning = text.left(m.capturedStart() +1).trimmed();
-        }else{
-            meaning = text.trimmed();
-        }
-    }
-
-    return meaning;
-}
-
-QStringList HelpPanel::extractOptions(const QString &text) const{
-    QStringList options;
-    if(text.isEmpty())return options;
-
-    QRegularExpression optPattern(R"(-\s+(\w[\w\s]*?)[\s]*[:\-\x{2013}\x{2014}]\s*(.+))");
-    auto it = optPattern.globalMatch(text);
-    while(it.hasNext()){
-        auto match =it.next();
-        QString name = match.captured(1).trimmed();
-        QString desc = match.captured(2).trimmed();
-        options << name + "|" +desc;
-    }
-
-    return options;
-}
-
-QString HelpPanel::parseOptionsListHtml(const QString &text) const{
-    QStringList options = extractOptions(text);
-    if(options.isEmpty()) return QString();
-
+QString HelpPanel::BooleanHelp(OptionsItem *item)const{
     QString html;
-    html += "<table cellspacing='0' cellpadding='0' style='margin: 4px 0;'>";
+    QString toolTip = item->toolTip();
+    QString currentVal = detectCurrentValue(item);
+    bool isTrue = (currentVal.toLower() == "true" || currentVal == "1");
 
-    for(const QString &opt : options){
-        QStringList parts = opt.split('|',Qt::KeepEmptyParts);
-        QString name = parts.value(0);
-        QString desc = parts.value(1);
-
-        html += QString(
-            "<tr>"
-            "  <td style='padding: 4px 0;'>"
-            "    <div style='background: #f0f4f8; border-radius: 4px; "
-            "         padding: 6px 10px; margin-bottom: 2px;'>"
-            "      <span style='font-weight: bold; color: #2060a0;'>%1</span>"
-            "      <span style='color: #555;'> — %2</span>"
-            "    </div>"
-            "  </td>"
-            "</tr>"
-        ).arg(name, desc);
-    }
-
-    html += "</table>";
-    return html;
-}
-
-/*Type-specific info*/
-
-QString HelpPanel::booleanEffectHtml(OptionsItem *item) const{
-    QString name = item->name().toLower();
-    QString key = item->key().toLower();
-    QString whats = item->whatsThis();
-    QString desc = whats.isEmpty() ? item->toolTip() : whats;
-
-    //check helpDb for richer description
-    if(helpDb_.contains(item->key())) desc =helpDb_[item->key()].description;
+    html += sectionHeader("Effect");
 
     QString trueEffect, falseEffect;
-
-    if(name.contains("enable") || key.contains("enable")){
-        QString feature = name;
-        feature.remove(QRegularExpression("^enable[sd]?\\s*", QRegularExpression::CaseInsensitiveOption));
-
-        if (feature.isEmpty()) feature = "this feature";
-        
-        trueEffect =QString("Enables %1").arg(feature);
-        falseEffect = QString("Disables %1").arg(feature);
-    }else if(!desc.isEmpty()){
-        QString cleanDesc = desc.trimmed();
-        
-        cleanDesc.remove(QRegularExpression("<[^>]*>")); // Strip HTML tags for the effect row
-        if (cleanDesc.endsWith('.')) cleanDesc.chop(1);
-
-        QRegularExpression firstSentence(R"(^(.+?\.)\s)");  // Take just the first sentence for the effect
-        auto m = firstSentence.match(cleanDesc);
-
-        if(m.hasMatch()){
-            cleanDesc = m.captured(1);
-            if(cleanDesc.endsWith('.'))cleanDesc.chop(1);
-        }
-
-        if(cleanDesc.startsWith("Enable", Qt::CaseInsensitive) ||
-            cleanDesc.startsWith("Control", Qt::CaseInsensitive)){
-            trueEffect = cleanDesc;
-            falseEffect = cleanDesc;
-            if(cleanDesc.startsWith("Enable", Qt::CaseInsensitive))
-                falseEffect.replace(QRegularExpression("^Enable[s]?", QRegularExpression::CaseInsensitiveOption), "Disable");
-            else if(cleanDesc.startsWith("Control", Qt::CaseInsensitive))
-                falseEffect.replace(QRegularExpression("^Controls", QRegularExpression::CaseInsensitiveOption), "Disables");
-        }else if(cleanDesc.startsWith("Whether",Qt::CaseInsensitive)){
-            QString action = cleanDesc;
-
-            action.remove(QRegularExpression("^Whether\\s+(to\\s+)?", QRegularExpression::CaseInsensitiveOption));
-
-            QString capitalized = action.left(1).toUpper() +action.mid(1);
-            trueEffect = capitalized;
-            falseEffect = QString("Does NOT %1").arg(action);
+    if(!toolTip.isEmpty()){
+        if(toolTip.startsWith("Enable", Qt::CaseInsensitive)){
+            trueEffect = toolTip;
+            falseEffect = toolTip;
+            falseEffect.replace(QRegularExpression("^Enable[s]?", 
+                QRegularExpression::CaseInsensitiveOption), "Disable");
+        }else if(toolTip.startsWith("Store", Qt::CaseInsensitive)){
+            trueEffect = toolTip;
+            falseEffect = QString("Do not %1").arg(toolTip.left(1).toLower() + toolTip.mid(1));
         }else{
-            trueEffect = cleanDesc;
-            falseEffect = QString("Disables %1").arg(cleanDesc.left(1).toLower() + cleanDesc.mid(1));
+            trueEffect = toolTip;
+            falseEffect = QString("Disabled");
         }
     }else{
-        QString label = item->name().isEmpty() ? item->key() : item->name();
-        trueEffect = QString("Enables %1").arg(label.toLower());
-        falseEffect = QString("Disables %1").arg(label.toLower());
+        trueEffect = "Enabled";
+        falseEffect = "Disabled";
     }
 
-    QString html;
-    html += effectRow("true", trueEffect, "#e8f5e9");
-    html += effectRow("false", falseEffect, "#fce4ec");
+    QString trueMarker = "";
+    QString falseMarker = "";
+    QString trueStyle = "color: #2e7d32; font-weight: bold;";
+    QString falseStyle = "color: #c62828; font-weight: bold;";
+
+    html += QString("<tr><td style='padding: 2px 0;'>"
+        "  <span style='%1'>• True: %2%3</span><br/>"
+        "  <span style='%4'>• False: %5%6</span>"
+        "</td></tr>"
+    ).arg(trueStyle, trueEffect, trueMarker,
+          falseStyle, falseEffect, falseMarker);
+
+    html += sectionHeader("Current Value");
+    QString valStr = isTrue ? "true" : "false";
+    QString bg = isTrue ? "#e8f5e9" : "#fce4ec";
+    QString color = isTrue ? "#2e7d32" : "#c62828";
+    html += QString("<tr><td style='padding: 2px 0;'>"
+        "  <code style='background: %1; color: %2; padding: 2px 8px; "
+        "  border-radius: 3px; font-size: 10pt; font-weight: bold;'>%3</code>"
+        "</td></tr>").arg(bg, color, valStr);
+
     return html;
 }
 
-QString HelpPanel::typeInfoHtml(OptionsItem *item) const{
-    QVariant val = item->value();
+QString HelpPanel::EnumHelp(OptionsItem *item)const{
     QString html;
+    html += sectionHeader("Options");
 
-    for(auto it = widgetIndexMap_.constBegin(); it !=widgetIndexMap_.constEnd(); ++it){
-        if(!it.value().isValid()) continue;
-        OptionsItem *mappedItem = static_cast<OptionsItem *>(it.value().internalPointer());
-        if(mappedItem != item)continue;
+    EnumOptionsItem *enumItem = dynamic_cast<EnumOptionsItem *>(item);
+    if(!enumItem) return html;
 
-        QWidget *widget = it.key();
+    const QStringList &values = enumItem->values();
+    const QStringList &labels = enumItem->valueLabels();
+    QString currentVal = detectCurrentValue(item);
 
-        /*boolean box*/
-        QComboBox *combo = qobject_cast<QComboBox *>(widget);
-        if (combo && combo->count() == 2) {
-            QString item0 = combo->itemText(0).toLower();
-            QString item1 = combo->itemText(1).toLower();
-            if ((item0 =="false" && item1 == "true") ||
-                (item0== "true" && item1 == "false")) {
-                html += sectionHeader("Type");
-                html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
-                            .arg(typeBadge("Boolean"));
-                html += sectionHeader("Effect");
-                html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
-                            .arg(booleanEffectHtml(item));
-                return html;
-            }
-        }
+    QString whats = item->whatsThis();
 
-        /*enum combo box*/
-        if(combo && combo->count() > 0){
-            html += sectionHeader("Type");
-            html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
-                        .arg(typeBadge("Selection"));
+    QMap<QString, QString> valueDescriptions;
+    QStringList tipLines;
 
-            QString whats = item->whatsThis();
-            QStringList parsed = extractOptions(whats.isEmpty() ? item->toolTip() : whats);
-            if(parsed.isEmpty()){
-                html += sectionHeader("Options");
-                QString optsHtml;
-                for(int i = 0; i < combo->count(); ++i){
-                    QString tipText = combo->itemData(i, Qt::ToolTipRole).toString();
-                    if (tipText.isEmpty()) tipText = combo->itemText(i);
-                    optsHtml += effectRow(combo->itemText(i), tipText, (i % 2 == 0) ? "#f0f4f8" : "#e8ecf0");
+    if(!whats.isEmpty()){
+        QStringList lines = whats.split('\n');
+        for(const QString &line : lines){
+            QString trimmed = line.trimmed();
+            if(trimmed.isEmpty()) continue;
+
+            if(trimmed.startsWith("- ") || trimmed.startsWith("• ")){
+                QString entry = trimmed.mid(2).trimmed();
+                int colonPos = entry.indexOf(':');
+                if(colonPos > 0){
+                    QString key = entry.left(colonPos).trimmed();
+                    QString desc = entry.mid(colonPos + 1).trimmed();
+                    for(int i = 0; i < values.size(); ++i){
+                        if(key == values[i] || (i < labels.size() && key == labels[i])){
+                            valueDescriptions[values[i]] = desc;
+                            break;
+                        }
+                    }
                 }
-                html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>").arg(optsHtml);
+            }else{
+                QString tip = item->toolTip();
+                if(trimmed != tip && !trimmed.isEmpty()) tipLines.append(trimmed);
             }
-            return html;
         }
-
-        /*checkbox*/
-        QCheckBox *check = qobject_cast<QCheckBox *>(widget);
-        if(check){
-            html += sectionHeader("Type");
-            html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
-                        .arg(typeBadge("Boolean"));
-            html += sectionHeader("Effect");
-            html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
-                        .arg(booleanEffectHtml(item));
-            return html;
-        }
-
-        /*spinbox*/
-        QSpinBox *spin = qobject_cast<QSpinBox *>(widget);
-        if (spin) {
-            html += sectionHeader("Type");
-            html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
-                        .arg(typeBadge("Integer"));
-            QString rangeStr = QString("%1 – %2")
-                .arg(spin->minimum()).arg(spin->maximum());
-            html += sectionHeader("Range");
-            html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
-                        .arg(codeBlock(rangeStr));
-            return html;
-        }
-
-        QDoubleSpinBox *dspin = qobject_cast<QDoubleSpinBox *>(widget);
-        if(dspin){
-            html += sectionHeader("Type");
-            html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
-                        .arg(typeBadge("Float"));
-            QString rangeStr = QString("%1 – %2")
-                .arg(dspin->minimum(), 0, 'g', 6)
-                .arg(dspin->maximum(), 0, 'g', 6);
-            html += sectionHeader("Range");
-            html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
-                        .arg(codeBlock(rangeStr));
-            if (!qFuzzyIsNull(dspin->singleStep())) {
-                html += sectionHeader("Step size");
-                html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
-                            .arg(codeBlock(QString::number(dspin->singleStep(), 'g', 6)));
-            }
-            return html;
-        }
-
-        //detect numeric vs text
-        QLineEdit *le = qobject_cast<QLineEdit *>(widget);
-        if(le){
-            bool isNumeric = false;
-            QString valStr = val.toString().trimmed();
-            if(!valStr.isEmpty()){
-                valStr.toDouble(&isNumeric);
-                if(!isNumeric && valStr.startsWith('[') && valStr.endsWith(']')){
-                    html += sectionHeader("Type");
-                    html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
-                                .arg(typeBadge("Array"));
-                    html += sectionHeader("Format");
-                    html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
-                                .arg(codeBlock("[x, y, z]"));
-                    return html;
-                }
-            }
-            html += sectionHeader("Type");
-            html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
-                        .arg(typeBadge(isNumeric ? "Float" : "Text"));
-            return html;
-        }
-
-        break;
     }
 
-    //fallback
-    switch (static_cast<QMetaType::Type>(val.type())){
-    case QMetaType::Bool:
-        html += sectionHeader("Type");
-        html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
-                    .arg(typeBadge("Boolean"));
-        html += sectionHeader("Effect");
-        html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
-                    .arg(booleanEffectHtml(item));
-        break;
-    case QMetaType::Int:
-    case QMetaType::LongLong:
-        html += sectionHeader("Type");
-        html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
-                    .arg(typeBadge("Integer"));
-        break;
-    case QMetaType::Double:
-    case QMetaType::Float:
-        html += sectionHeader("Type");
-        html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>")
-                    .arg(typeBadge("Float"));
-        break;
-    default:
-        break;
+    QString optionsBox;
+    optionsBox += "<div style='background: #f4f4f4; border: 1px solid #ddd; "
+                  "border-radius: 4px; padding: 6px 10px; margin: 2px 0;'>";
+
+    for(int i = 0; i < values.size(); ++i){
+        bool isCurrent = (values[i] == currentVal);
+        QString label = (i < labels.size() && !labels[i].isEmpty()) ? labels[i] : values[i];
+        QString desc = valueDescriptions.value(values[i], "");
+
+        QString nameStyle;
+        if(isCurrent)
+            nameStyle = "color: #1565c0; font-weight: bold;";
+        else
+            nameStyle = "font-weight: bold; color: #333;";
+
+        optionsBox += "<div style='padding: 3px 0;'>";
+
+        if(!desc.isEmpty()){
+            optionsBox += QString("<span style='%1'>%2</span>"
+                " &mdash; <span style='color: #666;'>%3</span>")
+                .arg(nameStyle, label, desc);
+        } else {
+            optionsBox += QString("<span style='%1'>%2</span>").arg(nameStyle, label);
+        }
+
+        optionsBox += "</div>";
+    }
+    optionsBox += "</div>";
+
+    html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>").arg(optionsBox);
+
+    if(!tipLines.isEmpty()){
+        html += sectionHeader("Note");
+        QString noteText = tipLines.join("<br/>");
+        html += QString("<tr><td style='padding: 2px 0 10px 0;'>"
+            "<div style='background: #c8d1f6; border: 1px solid #aed5f3; "
+            "border-radius: 4px; padding: 6px 10px; margin: 2px 0;'>"
+            "<span style='font-size: 9pt; color: #555; font-style: italic;'>%1</span>"
+            "</div>"
+            "</td></tr>").arg(noteText);
+    }
+
+    if(!currentVal.isEmpty()){
+        html += sectionHeader("Current Value");
+        html += QString("<tr><td style='padding: 2px 0;'>"
+            "<span style='font-size: 9pt; font-weight: bold; color: #1565c0;'>\"%1\"</span>"
+            "</td></tr>").arg(currentVal);
     }
 
     return html;
 }
 
-/*Constructor and Widget Registration*/
+QString HelpPanel::NumericHelp(OptionsItem *item) const{
+    QString html;
+    html += sectionHeader("Range");
+
+    double minVal = 0, maxVal = 0;
+    if(auto *fi = dynamic_cast<FloatOptionsItem *>(item)){
+        minVal = fi->min();
+        maxVal = fi->max();
+    }else if(auto *ii = dynamic_cast<IntOptionsItem *>(item)){
+        minVal = ii->min();
+        maxVal = ii->max();
+    }
+
+    QString currentVal = detectCurrentValue(item);
+
+    html += QString("<tr><td style='padding: 2px 0;'>"
+        "  <span style='font-size: 10pt;'>%1 — %2</span>"
+        "</td></tr>").arg(minVal).arg(maxVal);
+
+    if(!currentVal.isEmpty()) {
+        html += sectionHeader("Current Value");
+        html += QString("<tr><td style='padding: 2px 0;'>"
+            "  <span style='font-size: 12pt; font-weight: bold; color: #1565c0;'>%1</span>"
+            "</td></tr>").arg(currentVal);
+    }
+    return html;
+}
+
+QString HelpPanel::VectorHelp(OptionsItem *item)const{
+    QString html;
+    QString currentVal = detectCurrentValue(item);
+
+    double minVal = 0, maxVal = 0;
+    if(auto *vi = dynamic_cast<VectorOptionsItem *>(item)){
+        minVal = vi->min();
+        maxVal = vi->max();
+    }else if(auto *ivi = dynamic_cast<IVectorOptionsItem *>(item)){
+        minVal = ivi->min();
+        maxVal = ivi->max();
+    }
+
+    html += sectionHeader("Element Range");
+    html += QString("<tr><td style='padding: 2px 0;'>"
+        "  <span style='font-size: 9pt;'>%1 — %2</span>"
+        "</td></tr>").arg(minVal).arg(maxVal);
+
+    if(!currentVal.isEmpty()) {
+        html += sectionHeader("Current Value");
+        html += QString("<tr><td style='padding: 2px 0;'>"
+            "  <span style='font-size: 9pt; font-weight: bold; color: #1565c0;'>%1</span>"
+            "</td></tr>").arg(currentVal);
+    }
+    return html;
+}
 
 HelpPanel::HelpPanel(OptionsModel *model, QWidget *parent): QWidget(parent), model_(model){
-    setObjectName("HelpPanel");
-    setMinimumWidth(250);
-    setMaximumWidth(380);
 
-    buildHelpDatabase();
-
-    QVBoxLayout *layout = new QVBoxLayout(this);
+    auto *layout = new QVBoxLayout(this);
     layout->setContentsMargins(4, 4, 4, 4);
 
-    QHBoxLayout *header = new QHBoxLayout;
+    auto *header = new QHBoxLayout;
+    auto *header_label = new QLabel(tr("    Configuration Help"));
 
-    QLabel *title = new QLabel("<b>Config Help</b>");
-
-    QPushButton *closeBtn = new QPushButton(QString::fromUtf8("\xc3\x97"));
-    closeBtn->setFixedSize(24, 24);
-    closeBtn->setFlat(true);
-    connect(closeBtn, &QPushButton::clicked, this, &HelpPanel::toggleVisibility);
-    
-    header->addWidget(title);
+    header_label->setStyleSheet("font-weight: bold; font-size: 12pt;");
+    header->addWidget(header_label);
     header->addStretch();
-    header->addWidget(closeBtn);
-    
+
     layout->addLayout(header);
 
     browser_ = new QTextBrowser;
-    browser_->setOpenExternalLinks(false);
-    browser_->setReadOnly(true);
-    browser_->setStyleSheet(
-        "QTextBrowser {"
-        "  font-size: 10pt;"
-        "  padding: 4px;"
-        "  border: 1px solid #d0d0d0;"
-        "  border-radius: 4px;"
-        "  background: #fafafa;"
-        "}"
-    );
+    browser_->setOpenExternalLinks(true);
+    browser_->setFrameStyle(QFrame::NoFrame);
     layout->addWidget(browser_);
 
-    clear();
+    setMinimumWidth(220);
+    setMaximumWidth(350);
 }
 
 void HelpPanel::registerWidget(QWidget *editor, const QModelIndex &index){
-    if(!editor || !index.isValid()) return;
-
-    widgetIndexMap_.insert(editor, QPersistentModelIndex(index));
-    editor->setMouseTracking(true);
-    editor->setAttribute(Qt::WA_Hover, true);
-    editor->installEventFilter(this);
+    if(editor && index.isValid()){
+        widgetIndexMap_[editor] = QPersistentModelIndex(index);
+        editor->installEventFilter(this);
+    }
 }
+
 
 bool HelpPanel::eventFilter(QObject *watched, QEvent *event){
     if(event->type() == QEvent::FocusIn ||
-        event->type() == QEvent::Enter ||
-        event->type() == QEvent::HoverEnter) {
+        event->type() == QEvent::Enter){
         QWidget *w = qobject_cast<QWidget *>(watched);
         if(w && widgetIndexMap_.contains(w)){
             showHelpFor(widgetIndexMap_.value(w));
@@ -628,139 +276,129 @@ bool HelpPanel::eventFilter(QObject *watched, QEvent *event){
     return QWidget::eventFilter(watched, event);
 }
 
-void HelpPanel::toggleVisibility(){
-    setVisible(!isVisible());
-}
 
 void HelpPanel::showHelpFor(const QModelIndex &index){
-    if(!index.isValid()){
-        clear();
-        return;
-    }
+    if(!index.isValid()) return;
 
     OptionsItem *item = static_cast<OptionsItem *>(index.internalPointer());
-    if(!item){
-        clear();
-        return;
-    }
+    if(!item) return;
 
     browser_->setHtml(generateHelpHtml(item));
 }
 
-void HelpPanel::clear(){
-    browser_->setHtml("<html><body style='color: #999; padding: 20px; text-align: center;'>"
-        "<p style='font-size: 14pt;'></p>"
-        "<p><i>Hover over a configuration option<br/>to see its description.</i></p>"
-        "</body></html>"
-    );
+void HelpPanel::togglePanel(){
+    QSplitter *splitter = qobject_cast<QSplitter *>(parentWidget());
+    if(splitter){
+        QList<int> sizes = splitter->sizes();
+        if(sizes[1] == 0){
+            sizes[1] = 200;
+            splitter->setSizes(sizes);
+        } else {
+            sizes[1] = 0;
+            splitter->setSizes(sizes);
+        }
+    }else{
+        setVisible(!isVisible());
+    }
 }
 
-// Main HTML generation
+//Main HTML generation
 
 QString HelpPanel::generateHelpHtml(OptionsItem *item) const{
-    QString key = item->key();
+    if(!item) return QString();
 
-    bool hasDbEntry = helpDb_.contains(key);
+    QString type;
+    if(dynamic_cast<BoolOptionsItem *>(item))
+        type = "bool";
+    else if(dynamic_cast<EnumOptionsItem *>(item))
+        type = "selection";
+    else if(dynamic_cast<VectorOptionsItem *>(item))
+        type = "vector";
+    else if(dynamic_cast<IVectorOptionsItem *>(item))
+        type = "ivector";
+    else if(dynamic_cast<FloatOptionsItem *>(item))
+        type = "float";
+    else if(dynamic_cast<IntOptionsItem *>(item))
+        type = "int";
+    else if(dynamic_cast<StringOptionsItem *>(item))
+        type = "string";
+    else if(item->childCount() > 0)
+        type = "group";
+    else
+        type = "unknown";
 
-    HelpEntry entry;
-    if(hasDbEntry) entry = helpDb_.value(key);
+    QString html = "<html><head><style>"
+        "body { font-family: sans-serif; margin: 6px; }"
+        "table { width: 100%; border-collapse: collapse; }"
+        "</style></head><body><table>";
 
-    QString html;
-    html += "<html><body style='padding: 6px; font-family: sans-serif; "
-            "line-height: 1.4; color: #333;'>";
+    QString label = item->name().isEmpty() ? item->key() : item->name();
+    html += QString("<tr><td style='padding-bottom: 6px;'>"
+        "  <span style='font-size: 13pt; font-weight: bold; color: #0d47a1;'>%1</span>"
+        "</td></tr>").arg(label);
 
-    /*Title*/
-    QString name = item->name().isEmpty() ? key : item->name();
-    html += QString("<div style='border-bottom: 2px solid #2060a0; padding-bottom: 6px; "
-        "margin-bottom: 8px;'>"
-        "  <span style='font-size: 14pt; font-weight: bold; color: #2060a0;'>%1</span>"
-        "</div>"
-    ).arg(name);
 
-    html += "<table width='100%' cellspacing='0' cellpadding='0'>";
+    html += sectionHeader("Internal Name");
+    html += QString("<tr><td style='padding: 2px 0 6px 0;'>"
+        "  <code style='font-size: 10pt; background: #f5f5f5; padding: 2px 4px;'>%1</code>"
+        "</td></tr>").arg(item->key());
 
-    /*Internal name*/
-    if(!key.isEmpty()){
-        html += sectionHeader("Internal name");
-        html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>").arg(codeBlock(key));
-    }
-
-    /*Description, prefer helpDb, fall back to whatsThis/toolTip*/
-    QString whats = item->whatsThis();
-    QString tip = item->toolTip();
-    QString descText;
-
-    if(hasDbEntry && !entry.description.isEmpty()){
-        descText = entry.description;
-    }else{
-        descText = whats.isEmpty() ? tip : whats;
-    }
-
-    QString meaning = extractMeaning(descText);
-    if(!meaning.isEmpty()){
+    QString toolTip = item->toolTip();
+    if(!toolTip.isEmpty()){
         html += sectionHeader("Description");
         html += QString("<tr><td style='padding: 2px 0 10px 0;'>"
             "  <span style='font-size: 10pt;'>%1</span>"
-            "</td></tr>").arg(hasDbEntry ? descText : meaning);
+            "</td></tr>").arg(toolTip);
     }
 
-    if(hasDbEntry && !entry.units.isEmpty()){
-        html += sectionHeader("Units");
-        html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>").arg(typeBadge(entry.units));
-    }
+    QString whatsThis = item->whatsThis();
 
-    QString typeHtml = typeInfoHtml(item);
-    bool isSelectionType = typeHtml.contains("SELECTION", Qt::CaseInsensitive);
-    html += typeHtml;
+    html += sectionHeader("Type");
+    QString typeDisplay = type.toUpper();
+    html += QString("<tr><td style='padding: 2px 0 6px 0;'>"
+        "  <span style='font-size: 10pt; font-weight: bold; color: #1565c0;'>%1</span>"
+        "</td></tr>").arg(typeDisplay);
 
-    if(isSelectionType){
-        QString meaningSource = whats.isEmpty() ? tip : whats;
-        QString optionsHtml = parseOptionsListHtml(meaningSource);
-
-        if(!optionsHtml.isEmpty()){
-            html += sectionHeader("Options");
-            html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>").arg(optionsHtml);
+    if(type == "bool"){
+        html += BooleanHelp(item);
+    }else if(type == "selection") {
+        html += EnumHelp(item);
+    }else if(type == "int" || type == "float") {
+        html += NumericHelp(item);
+    }else if(type == "vector" || type == "ivector") {
+        html += VectorHelp(item);
+    }else if(type == "string") {
+        QString currentVal = detectCurrentValue(item);
+        if(!currentVal.isEmpty()){
+            html += sectionHeader("Current Value");
+            html += QString("<tr><td style='padding: 2px 0;'>"
+                "  <span style='font-size: 11pt; font-weight: bold; color: #1565c0;'>%1</span>"
+                "</td></tr>").arg(currentVal);
         }
     }
-
-    if(hasDbEntry && !entry.tip.isEmpty()){
-        html += sectionHeader("Tip");
-        html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>").arg(infoBox(entry.tip,"#fff8e1"));
-    }
-
-    if(!hasDbEntry && !tip.isEmpty() && tip != whats && tip != meaning){
-        QString tipMeaning = extractMeaning(tip);
-        if(tipMeaning != meaning && !tipMeaning.isEmpty()){
+    if(!whatsThis.isEmpty() && type != "selection"){
+    
+        QString cleanWhats = whatsThis;
+    
+        if(cleanWhats.startsWith(toolTip + "\n\n"))
+            cleanWhats = cleanWhats.mid(toolTip.length() + 2);
+        else if(cleanWhats.startsWith(toolTip + "\n"))
+            cleanWhats = cleanWhats.mid(toolTip.length() + 1);
+        else if(cleanWhats == toolTip)
+            cleanWhats.clear();
+    
+        if(!cleanWhats.isEmpty()){
             html += sectionHeader("Note");
-            html += QString("<tr><td style='padding: 2px 0 10px 0;'>%1</td></tr>"
-            ).arg(infoBox(tipMeaning, "#fff8e1"));
+            QString formatted = cleanWhats;
+            formatted.replace("\n", "<br/>");
+            html += QString("<tr><td style='padding: 2px 0 10px 0;'>"
+                "  <div style='background: #c8d1f6; border: 1px solid #aed5f3; "
+                "  border-radius: 4px; padding: 6px 10px; margin: 2px 0;'>"
+                "  <span style='font-size: 9pt; color: #555; font-style: italic;'>%1</span>"
+                "  </div>"
+                "</td></tr>").arg(formatted);
         }
     }
-
-    QVariant val = item->value();
-    if(val.isValid() && !val.isNull()){
-        html += sectionHeader("Current value");
-
-        QString valStr = val.toString();
-        QString bg = "#f4f4f4";
-
-        if(static_cast<QMetaType::Type>(val.type()) == QMetaType::Bool){
-            bg = val.toBool() ? "#e8f5e9" : "#fce4ec";
-            valStr = val.toBool() ? "true" : "false";
-        }else if (valStr.toLower() == "true"){
-            bg = "#e8f5e9";
-        }else if (valStr.toLower() == "false"){
-            bg = "#fce4ec";
-        }
-
-        html += QString("<tr><td style='padding: 2px 0 10px 0;'>"
-            "  <code style='background: %2; padding: 2px 8px; "
-            "  border-radius: 3px; font-size: 10pt; font-weight: bold;'>%1</code>"
-            "</td></tr>"
-        ).arg(valStr, bg);
-    }
-
-    html += "</table>";
-    html += "</body></html>";
+    html += "</table></body></html>";
     return html;
 }

--- a/source/gui/helppanel.h
+++ b/source/gui/helppanel.h
@@ -1,0 +1,57 @@
+#ifndef HELPPANEL_H
+#define HELPPANEL_H
+
+#include <QWidget>
+#include <QMap>
+
+class QTextBrowser;
+class QModelIndex;
+class OptionsModel;
+class OptionsItem;
+
+struct HelpEntry {
+    QString description;   
+    QString tip;           
+    QString units;         
+    QString defaultValue;       
+};
+
+class HelpPanel : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit HelpPanel(OptionsModel *model, QWidget *parent = nullptr);
+
+    void registerWidget(QWidget *editor, const QModelIndex &index);
+
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
+public slots:
+    void showHelpFor(const QModelIndex &index);
+    void clear();
+    void toggleVisibility();
+
+private:
+    QString generateHelpHtml(OptionsItem *item) const;
+    QString parseOptionsListHtml(const QString &text) const;
+    QString extractMeaning(const QString &text) const;
+    QStringList extractOptions(const QString &text) const;
+    QString typeInfoHtml(OptionsItem *item) const;
+    QString booleanEffectHtml(OptionsItem *item) const;
+
+    QString sectionHeader(const QString &title) const;
+    QString codeBlock(const QString &text) const;
+    QString infoBox(const QString &text, const QString &color = "#e8f0fe") const;
+    QString typeBadge(const QString &typeName) const;
+    QString effectRow(const QString &value, const QString &desc, const QString &color) const;
+
+    void buildHelpDatabase();
+
+    QTextBrowser *browser_;
+    OptionsModel *model_;
+    QMap<QWidget *, QPersistentModelIndex> widgetIndexMap_;
+    QMap<QString, HelpEntry> helpDb_;
+};
+
+#endif // HELPPANEL_H

--- a/source/gui/helppanel.h
+++ b/source/gui/helppanel.h
@@ -9,15 +9,13 @@ class QModelIndex;
 class OptionsModel;
 class OptionsItem;
 
-struct HelpEntry {
+struct HelpEntry{
     QString description;   
     QString tip;           
-    QString units;         
-    QString defaultValue;       
+    QString units;               
 };
 
-class HelpPanel : public QWidget
-{
+class HelpPanel : public QWidget{
     Q_OBJECT
 
 public:
@@ -54,4 +52,4 @@ private:
     QMap<QString, HelpEntry> helpDb_;
 };
 
-#endif // HELPPANEL_H
+#endif 

--- a/source/gui/helppanel.h
+++ b/source/gui/helppanel.h
@@ -8,12 +8,7 @@ class QTextBrowser;
 class QModelIndex;
 class OptionsModel;
 class OptionsItem;
-
-struct HelpEntry{
-    QString description;   
-    QString tip;           
-    QString units;               
-};
+class QPushButton;
 
 class HelpPanel : public QWidget{
     Q_OBJECT
@@ -21,35 +16,26 @@ class HelpPanel : public QWidget{
 public:
     explicit HelpPanel(OptionsModel *model, QWidget *parent = nullptr);
 
-    void registerWidget(QWidget *editor, const QModelIndex &index);
-
-    bool eventFilter(QObject *watched, QEvent *event) override;
-
-public slots:
     void showHelpFor(const QModelIndex &index);
-    void clear();
-    void toggleVisibility();
+    void registerWidget(QWidget *editor, const QModelIndex &index);
+    bool eventFilter(QObject *watched, QEvent *event) override;
+    void togglePanel();
 
 private:
-    QString generateHelpHtml(OptionsItem *item) const;
-    QString parseOptionsListHtml(const QString &text) const;
-    QString extractMeaning(const QString &text) const;
-    QStringList extractOptions(const QString &text) const;
-    QString typeInfoHtml(OptionsItem *item) const;
-    QString booleanEffectHtml(OptionsItem *item) const;
+    QString generateHelpHtml(OptionsItem *item)const ;
+    QString sectionHeader(const QString &title)const;
+    QString detectCurrentValue(OptionsItem *item)const;
+    QString BooleanHelp(OptionsItem *item)const;
+    QString EnumHelp(OptionsItem *item)const;
+    QString NumericHelp(OptionsItem *item)const;
+    QString VectorHelp(OptionsItem *item)const;
 
-    QString sectionHeader(const QString &title) const;
-    QString codeBlock(const QString &text) const;
-    QString infoBox(const QString &text, const QString &color = "#e8f0fe") const;
-    QString typeBadge(const QString &typeName) const;
-    QString effectRow(const QString &value, const QString &desc, const QString &color) const;
 
-    void buildHelpDatabase();
-
-    QTextBrowser *browser_;
     OptionsModel *model_;
+    QTextBrowser *browser_;
+    QPushButton *closeButton_;
+
     QMap<QWidget *, QPersistentModelIndex> widgetIndexMap_;
-    QMap<QString, HelpEntry> helpDb_;
 };
 
 #endif 

--- a/source/gui/helppanel.h
+++ b/source/gui/helppanel.h
@@ -33,7 +33,6 @@ private:
 
     OptionsModel *model_;
     QTextBrowser *browser_;
-    QPushButton *closeButton_;
 
     QMap<QWidget *, QPersistentModelIndex> widgetIndexMap_;
 };

--- a/source/gui/mainui.cpp
+++ b/source/gui/mainui.cpp
@@ -114,19 +114,23 @@ MainUI::MainUI(QWidget *parent) : QWidget(parent), quickStartWidget(nullptr)
     toolBar->addStretch();
 
     QToolButton *helpToggle = new QToolButton;
-    helpToggle->setText("Toggle Help");
+    helpToggle->setText("Hide Help");
     helpToggle->setToolTip(tr("Show/Hide Help Panel"));
     helpToggle->setCheckable(true);
     helpToggle->setChecked(true);
     helpToggle->setStyleSheet("QToolButton { font-weight: bold; font-size: 10pt; border: 1px solid #aaa; "
         "border-radius: 4px; padding: 4px 10px; background: #e3f2fd; color: #1565c0; }"
         "QToolButton:checked { background: #1565c0; color: white; }");
-        
+
     connect(helpToggle, &QToolButton::clicked, this, [helpToggle, this]() {
         helpPanel->togglePanel();
         QSplitter *splitter = qobject_cast<QSplitter *>(helpPanel->parentWidget());
         
-        if(splitter) helpToggle->setChecked(splitter->sizes()[1] > 0);
+        if(splitter){
+            bool visible = splitter->sizes()[1] > 0;    
+            helpToggle->setChecked(visible);
+            helpToggle->setText(visible ? tr("Hide Help") : tr("Show Help"));  
+        } 
     });
     toolBar->addWidget(helpToggle);
 

--- a/source/gui/mainui.cpp
+++ b/source/gui/mainui.cpp
@@ -7,6 +7,7 @@
 #include "simcontrolwidget.h"
 #include "resultsview.h"
 #include "tabularview.h"
+#include "helppanel.h"
 
 #include <QVBoxLayout>
 
@@ -76,10 +77,13 @@ MainUI::MainUI(QWidget *parent) : QWidget(parent), quickStartWidget(nullptr)
     QVBoxLayout *vbox = new QVBoxLayout;
     vbox->addWidget(_stackedWidget);
     vbox->addWidget(ctrlWidget);
+    
+    helpPanel = new HelpPanel(optionsModel, this);
 
     QHBoxLayout *layout = new QHBoxLayout;
     layout->addWidget(sidebar);
     layout->addLayout(vbox);
+    layout->addWidget(helpPanel);
     setLayout(layout);
     layout->setSpacing(0);
     layout->setContentsMargins(0, 0, 0, 0);
@@ -107,6 +111,7 @@ MainUI::MainUI(QWidget *parent) : QWidget(parent), quickStartWidget(nullptr)
     connect(pageButtonGrp, &QButtonGroup::idClicked, this, &MainUI::changePage);
     connect(driverObj_, &McDriverObj::fileNameChanged, this, &MainUI::updateWindowTitle);
     connect(driverObj_, &McDriverObj::modificationChanged, this, &MainUI::updateWindowTitle);
+
 
     driverObj_->loadJsonTemplate();
 

--- a/source/gui/mainui.cpp
+++ b/source/gui/mainui.cpp
@@ -24,6 +24,7 @@
 #include <QScreen>
 #include <QFile>
 #include <QButtonGroup>
+#include <QSplitter>
 
 #define SIDEBAR_W 70
 #define SIDEBAR_H 70
@@ -77,13 +78,10 @@ MainUI::MainUI(QWidget *parent) : QWidget(parent), quickStartWidget(nullptr)
     QVBoxLayout *vbox = new QVBoxLayout;
     vbox->addWidget(_stackedWidget);
     vbox->addWidget(ctrlWidget);
-    
-    helpPanel = new HelpPanel(optionsModel, this);
 
     QHBoxLayout *layout = new QHBoxLayout;
     layout->addWidget(sidebar);
     layout->addLayout(vbox);
-    layout->addWidget(helpPanel);
     setLayout(layout);
     layout->setSpacing(0);
     layout->setContentsMargins(0, 0, 0, 0);
@@ -92,8 +90,52 @@ MainUI::MainUI(QWidget *parent) : QWidget(parent), quickStartWidget(nullptr)
     welcomeView = new WelcomeView(this);
     push(tr("Welcome"), welcomeView);
 
+    helpPanel = new HelpPanel(optionsModel);
+
     optionsView = new SimulationOptionsView(this);
-    push(tr("Configuration"), optionsView);
+
+    auto *configSplitter = new QSplitter(Qt::Horizontal);
+    configSplitter->addWidget(optionsView);
+    configSplitter->addWidget(helpPanel);
+    
+    configSplitter->setStretchFactor(0, 3);
+    configSplitter->setStretchFactor(1, 1);
+
+    configSplitter->setCollapsible(0, false);
+    configSplitter->setCollapsible(1, true);
+
+    configSplitter->setSizes({600, 200});
+
+    QWidget *configPage = new QWidget;
+    QVBoxLayout *configLayout = new QVBoxLayout(configPage);
+    configLayout->setContentsMargins(0, 0, 0, 0);
+
+    QHBoxLayout *toolBar = new QHBoxLayout;
+    toolBar->addStretch();
+
+    QToolButton *helpToggle = new QToolButton;
+    helpToggle->setText("Toggle Help");
+    helpToggle->setToolTip(tr("Show/Hide Help Panel"));
+    helpToggle->setCheckable(true);
+    helpToggle->setChecked(true);
+    helpToggle->setStyleSheet("QToolButton { font-weight: bold; font-size: 10pt; border: 1px solid #aaa; "
+        "border-radius: 4px; padding: 4px 10px; background: #e3f2fd; color: #1565c0; }"
+        "QToolButton:checked { background: #1565c0; color: white; }");
+        
+    connect(helpToggle, &QToolButton::clicked, this, [helpToggle, this]() {
+        helpPanel->togglePanel();
+        QSplitter *splitter = qobject_cast<QSplitter *>(helpPanel->parentWidget());
+        
+        if(splitter) helpToggle->setChecked(splitter->sizes()[1] > 0);
+    });
+    toolBar->addWidget(helpToggle);
+
+    configLayout->addLayout(toolBar);
+    configLayout->addWidget(configSplitter);
+
+    helpPanel->setVisible(true);
+    
+    push(tr("Configuration"), configPage);
 
     // runView = new RunView(this);
     // push(tr("Run"), runView);

--- a/source/gui/mainui.h
+++ b/source/gui/mainui.h
@@ -10,6 +10,7 @@ class QToolButton;
 class QLabel;
 class QButtonGroup;
 class HelpPanel;
+class QSplitter;
 
 class OptionsModel;
 class SimControlWidget;

--- a/source/gui/mainui.h
+++ b/source/gui/mainui.h
@@ -9,6 +9,7 @@ class QTextBrowser;
 class QToolButton;
 class QLabel;
 class QButtonGroup;
+class HelpPanel;
 
 class OptionsModel;
 class SimControlWidget;
@@ -26,12 +27,14 @@ class MainUI : public QWidget
     Q_OBJECT
 
 public:
-    OptionsModel *optionsModel;
+OptionsModel *optionsModel;
 
-    SimulationOptionsView *optionsView;
+SimulationOptionsView *optionsView;
 
-    explicit MainUI(QWidget *parent = nullptr);
-    ~MainUI();
+explicit MainUI(QWidget *parent = nullptr);
+~MainUI();
+
+HelpPanel *helpPanel;
 
     // const McDriverObj* driverObj() const { return ions_driver; }
     McDriverObj *driverObj() { return driverObj_; }

--- a/source/gui/optionsmodel.h
+++ b/source/gui/optionsmodel.h
@@ -82,6 +82,9 @@ protected:
 class FloatOptionsItem : public OptionsItem
 {
 public:
+
+    double min() const { return fmin_; }
+    double max() const { return fmax_; }
     FloatOptionsItem(double fmin, double fmax, int digits, const QString &key, const QString &name,
                      OptionsItem *parent);
     virtual QWidget *createEditor(QWidget *parent) const override;
@@ -97,6 +100,9 @@ protected:
 class IntOptionsItem : public OptionsItem
 {
 public:
+    int min() const { return imin_; }
+    int max() const { return imax_; }
+
     IntOptionsItem(int imin, int imax, const QString &key, const QString &name,
                    OptionsItem *parent);
     // virtual QVariant value() const override;

--- a/source/gui/simulationoptionsview.cpp
+++ b/source/gui/simulationoptionsview.cpp
@@ -9,6 +9,7 @@
 #include "mainui.h"
 #include "mcdriverobj.h"
 #include "simboxview.h"
+#include "helppanel.h"
 
 #include <QJsonObject>
 #include <QVBoxLayout>
@@ -392,6 +393,8 @@ QFormLayout *SimulationOptionsView::createForm(const QModelIndex &parent, QWidge
         if (w) {
             mapper->addMapping(w, i, item->editorSignal());
             flayout->addRow(item->name(), w);
+
+            ionsui->helpPanel->registerWidget(w ,i);
         }
     }
     return flayout;

--- a/source/lib/options_spec.json
+++ b/source/lib/options_spec.json
@@ -54,11 +54,11 @@
                         "- None: Unscreened Coulomb potential",
                         "- Bohr: Bohr screening",
                         "- KrC: Kr-C screening",
-                        "- Moliere - Moliere screening",
-                        "- ZBL - Ziegler-Biersack-Littmark universal screening",
-                        "- ZBL_MAGIC - ZBL with analytic approx. formula",
+                        "- Moliere: Moliere screening",
+                        "- ZBL: Ziegler-Biersack-Littmark universal screening",
+                        "- ZBL_MAGIC: ZBL with analytic approx. formula",
                         "  ",
-                        "For Unscreened Coulomb and ZBL_MAGIK the scattering is calculated analytically.",
+                        "For Unscreened Coulomb and ZBL_MAGIC the scattering is calculated analytically.",
                         "In all other cases interpolation tables are used."
                     ]
                 },
@@ -206,7 +206,7 @@
                     "digits": 3,
                     "toolTip": "Minimum recoil energy in eV.",
                     "whatsThis": [
-                        "Events with recoil energy below this value will be ignoredif the scattering angle is also below min_scattering_angle.",
+                        "Events with recoil energy below this value will be ignored if the scattering angle is also below min_scattering_angle.",
                         "Applicable only when flight_path_type=Variable"
                     ]
                 },
@@ -220,7 +220,7 @@
                     "toolTip": "Minimum scattering angle in degrees.",
                     "whatsThis": [
                         "Refers to the projectile scattering angle in the lab reference frame.",
-                        "Events with scattering angle lower that this value will be ignotred if the recoil energy is also below min_recoil_energy.",
+                        "Events with scattering angle lower that this value will be ignored if the recoil energy is also below min_recoil_energy.",
                         "Applicable only when flight_path_type=Variable"
                     ]
                 },


### PR DESCRIPTION
This PR adds a contextual help panel to the OpenTRIM configuration GUI.
When hovering over a configuration option, a dedicated panel displays structured help information such as description, internal name, type, available options, units, tips, and current value.

What is included:
new HelpPanel widget
custom help database for clearer descriptions of important options
fallback to existing toolTip / whatsThis metadata if custom description does not exist

This implements a first version of the TODO idea for better configuration help through a foldable text/help widget in the GUI.
The aim is to make the configuration process more self-explanatory and reduce dependence on short standalone tooltips.

This is a first implementation pass, mainly focused on the general structure of the help panel. I expect that some wording and individual help entries can still be improved over review.



<img width="1181" height="705" alt="GUI1" src="https://github.com/user-attachments/assets/fca7ea33-a9fe-4189-9323-c73172d09bc7" />
<img width="1176" height="695" alt="GUI2" src="https://github.com/user-attachments/assets/7418e730-767f-4dbb-9956-54b79373f730" />
<img width="1184" height="698" alt="GUI3" src="https://github.com/user-attachments/assets/5f2e8615-04e1-4c02-bc11-910f4822eebd" />
