### PR TITLE
Fix/issue 24 multithread reproducibility

### DIFF
--- a/doc/reproducibility.md
+++ b/doc/reproducibility.md
@@ -1,0 +1,18 @@
+# Reproducibility of OpenTRIM results {#reproducibility}
+
+Monte-Carlo programs use pseudo-random number generator (RNG) algorithms which produce a very long sequence of numbers that are seemingly random and uncorrelated.
+
+The RNG seed sets effectively the point in this sequence where a specific Monte-Carlo run starts to read numbers.
+
+Thus, two runs of the same Monte-Carlo calculation, starting from the same seed will produce exactly the same result. This reproducibility reveals the pseudo-random character of these calculations. At the same time, it helps programmers correct bugs in the code, which are revealed when the reproducibility is broken.
+
+OpenTRIM should always produce exactly the same results when running the same simulation, with the same seed and for the same number of ion histories.
+
+A detail that has to be noted is that, in order for the results to be reproducible, OpenTRIM must also run **with the same number of threads**.
+Thus, for example, a single-thread run of 1000 ions will not produce the same results when 2 threads are used that simulate 500 ions each.
+
+This is due to the way RNGs are used in multi threaded applications. Each thread makes a very long "jump" in the random number sequence relative to the seed and starts reading numbers there. Thus, each thread has effectively its own number sequence. RNG algorithms provide a way to do this reproducibly, ensuring minimal correlation between thread sequences. However, the number of threads changes the actual pseudo-random sequence that the calculation uses.
+
+OpenTRIM uses the Xoshiro256+ RNG (https://prng.di.unimi.it/) with a period of \f$ 2^{256} - 1\f$. 
+
+\sa \ref RNG

--- a/doc/userdoc.md
+++ b/doc/userdoc.md
@@ -6,6 +6,7 @@
 - \subpage json_config "The JSON configuration file"
 - \subpage out_file "The HDF5 output archive"
 - \subpage tallies
+- \subpage reproducibility
 
 \page cliapp Using the command line application 
 

--- a/source/include/event_stream.h
+++ b/source/include/event_stream.h
@@ -102,6 +102,8 @@ public:
     void write(const event_buffer *ev);
     /// Merge data from another stream into this one
     int merge(event_stream &ev);
+    /// Merge multiple streams into this one, preserving event id order
+    int merge(std::vector<event_stream *> &v);
     /// Return true if the stream is open
     bool is_open() const { return fs_ != NULL; }
     /// Set the event_buffer prototype. The stream must be in the closed state;
@@ -114,6 +116,7 @@ public:
     void rewind();
     void clear();
     size_t read(float *buff, size_t nevents);
+    bool peekid(uint32_t &id);
     size_t write(const float *buff, size_t nevents);
 
 private:

--- a/source/include/mccore.h
+++ b/source/include/mccore.h
@@ -326,6 +326,18 @@ public:
     void mergeEvents(mccore &other);
 
     /**
+     * @brief Merge the events from a vector of simulation objects
+     *
+     * The streamed events from all objects in @p other are
+     * added to this object's event streams.
+     *
+     * The events in all objects in @p other are cleared.
+     *
+     * @param other a vector of simulation objects
+     */
+    void mergeEvents(std::vector<mccore *> &other);
+
+    /**
      * @brief Prepare for simulating @a nion histories
      *
      * Initialize internal counters so that the next call

--- a/source/include/mccore.h
+++ b/source/include/mccore.h
@@ -170,12 +170,20 @@ protected:
     // max # of ion histories to run
     size_t max_no_ions_;
 
-    // shared ion counter
-    std::shared_ptr<std::atomic_size_t> ion_counter_; // shared ion counter
-    std::atomic_size_t thread_ion_counter_; // per thread ion counter
+    /* variables for multi-threading */
 
+    // shared total ion counter = total # of simulated ion histories
+    std::shared_ptr<std::atomic_size_t> ion_counter_;
     // shared abort flag
-    std::shared_ptr<std::atomic_bool> abort_flag_; // thread safe abort simulation flag
+    std::shared_ptr<std::atomic_bool> abort_flag_;
+    // per thread ion id
+    size_t thread_ion_id_;
+    // id stride = number of threads
+    size_t ion_id_stride_;
+    // per thread ion counter
+    size_t thread_ion_counter_;
+    // thread max ions
+    size_t thread_max_no_ions_;
 
     // shared mutex for tally data
     std::shared_ptr<std::mutex> tally_mutex_;
@@ -213,8 +221,6 @@ public:
     // This number refers to all threads
     size_t ion_count() const { return *ion_counter_; }
     void setIonCount(size_t n) { *ion_counter_ = n; }
-    // Number of ions run in the current tread
-    size_t thread_ion_count() const { return thread_ion_counter_; }
 
     /// Returns the core simulation parameters
     const parameters &getSimulationParameters() const { return par_; }
@@ -320,6 +326,23 @@ public:
     void mergeEvents(mccore &other);
 
     /**
+     * @brief Prepare for simulating @a nion histories
+     *
+     * Initialize internal counters so that the next call
+     * to run() will simulate @a nion histories.
+     *
+     * The id of each simulated ion is
+     *
+     *   id = id0 + k * id_stride
+     *
+     *
+     * @param nions
+     * @param id0
+     * @param id_stride
+     */
+    void arm(size_t nions, size_t id0 = 0, size_t id_stride = 1);
+
+    /**
      * @brief Run the ion transport simulation
      *
      * This function runs the actual Monte-Carlo loop, repeating
@@ -336,7 +359,6 @@ public:
      */
     int run();
 
-    void clear_abort_flag() { *abort_flag_ = false; }
     void abort() { *abort_flag_ = true; }
     bool abort_flag() const { return *abort_flag_; }
 

--- a/source/include/mccore.h
+++ b/source/include/mccore.h
@@ -176,13 +176,14 @@ protected:
     std::shared_ptr<std::atomic_size_t> ion_counter_;
     // shared abort flag
     std::shared_ptr<std::atomic_bool> abort_flag_;
-    // per thread ion id
-    size_t thread_ion_id_;
+    // id of the next simulated ion
+    size_t next_ion_id_;
+    // id stride : next_id = id + stride
     // id stride = number of threads
     size_t ion_id_stride_;
-    // per thread ion counter
+    // per thread simulated ion counter
     size_t thread_ion_counter_;
-    // thread max ions
+    // max ions to be simulated by this thread
     size_t thread_max_no_ions_;
 
     // shared mutex for tally data
@@ -221,6 +222,8 @@ public:
     // This number refers to all threads
     size_t ion_count() const { return *ion_counter_; }
     void setIonCount(size_t n) { *ion_counter_ = n; }
+    size_t next_ion_id() const { return next_ion_id_; }
+    size_t thread_ion_count() const { return thread_ion_counter_; }
 
     /// Returns the core simulation parameters
     const parameters &getSimulationParameters() const { return par_; }
@@ -338,21 +341,26 @@ public:
     void mergeEvents(std::vector<mccore *> &other);
 
     /**
-     * @brief Prepare for simulating @a nion histories
+     * @brief Prepare for simulating @p N ion histories
      *
      * Initialize internal counters so that the next call
-     * to run() will simulate @a nion histories.
+     * to run() will simulate @p N histories.
      *
      * The id of each simulated ion is
      *
-     *   id = id0 + k * id_stride
+     *   id = id1 + k * id_stride, k=0,1,...,N-1
      *
+     * In multi-threaded runs, @p id_stride is set equal to
+     * the number of threads.
      *
-     * @param nions
-     * @param id0
-     * @param id_stride
+     * Ion history id is a 1-based index. The 1st simulated ion
+     * has id=1, etc
+     *
+     * @param N # of ions to simulate
+     * @param id1 id of the 1st ion
+     * @param id_stride id allocation stride
      */
-    void arm(size_t nions, size_t id0 = 0, size_t id_stride = 1);
+    void arm(size_t N, size_t id1 = 1, size_t id_stride = 1);
 
     /**
      * @brief Run the ion transport simulation

--- a/source/include/random_vars.h
+++ b/source/include/random_vars.h
@@ -98,16 +98,17 @@ public:
     Xoshiro256Plus(const Xoshiro256Plus &other) noexcept : m_state(other.m_state) { }
 
     /**
-     * @brief Set the internal state by a seed s
+     * @brief Set the internal state to a random value
      *
-     * s is used to initialize a std::mt19937_64 object, which is
+     * std::random_device is used to seed a std::mt19937_64 object,
+     * which is
      * then used to produce the internal state data.
      *
-     * @param s the seed used initialize the state
      */
-    void randomize(result_type s)
+    void randomize()
     {
-        std::mt19937_64 mt(s);
+        std::random_device rd;
+        std::mt19937_64 mt(rd());
 
         for (auto &state : m_state) {
             state = static_cast<std::uint64_t>(mt());

--- a/source/lib/event_stream.cpp
+++ b/source/lib/event_stream.cpp
@@ -165,6 +165,50 @@ int event_stream::merge(event_stream &ev)
     return 0; // successfully terminated
 }
 
+int event_stream::merge(std::vector<event_stream *> &v)
+{
+    if (!is_open())
+        return -1;
+    for (auto *p : v)
+        if (!p->is_open() || p->cols() != cols_)
+            return -1;
+
+    for (auto *p : v)
+        p->rewind();
+
+    std::vector<float> buff(cols_);
+
+    for (;;) {
+        // find the stream with the smallest peekid (loop A)
+        uint32_t min_id;
+        int min_idx = -1;
+        for (int i = 0; i < (int)v.size(); i++) {
+            uint32_t id;
+            if (v[i]->peekid(id) && (min_idx == -1 || id < min_id)) {
+                min_id = id;
+                min_idx = i;
+            }
+        }
+
+        if (min_idx == -1)
+            break;
+
+        // copy all consecutive events with min_id from that stream (loop B)
+        event_stream *src = v[min_idx];
+        uint32_t cur_id;
+        while (src->read(buff.data(), 1) == cols_) {
+            std::memcpy(&cur_id, buff.data(), sizeof(uint32_t));
+            if (cur_id != min_id) {
+                std::fseek(src->fs_, -(long)(cols_ * sizeof(float)), SEEK_CUR);
+                break;
+            }
+            write(buff.data(), 1);
+        }
+    }
+
+    return 0;
+}
+
 bool event_stream::set_event_prototype(const event_buffer &ev)
 {
     close_();
@@ -190,6 +234,16 @@ void event_stream::clear()
 size_t event_stream::read(float *buff, size_t nevents)
 {
     return is_open() ? std::fread(buff, sizeof(float), nevents * cols_, fs_) : 0;
+}
+
+bool event_stream::peekid(uint32_t &id)
+{
+    if (!is_open())
+        return false;
+    if (std::fread(&id, sizeof(uint32_t), 1, fs_) != 1)
+        return false;
+    std::fseek(fs_, -(long)sizeof(uint32_t), SEEK_CUR);
+    return true;
 }
 
 size_t event_stream::write(const float *buff, size_t nevents)

--- a/source/lib/mccore.cpp
+++ b/source/lib/mccore.cpp
@@ -9,8 +9,8 @@ mccore::mccore()
       target_(new target),
       ref_count_(new int(0)),
       ion_counter_(new std::atomic_size_t(0)),
-      thread_ion_counter_(0),
       abort_flag_(new std::atomic_bool()),
+      thread_ion_counter_(0),
       tally_mutex_(new std::mutex)
 {
 }
@@ -22,8 +22,8 @@ mccore::mccore(const parameters &p, const transport_options &t)
       target_(new target),
       ref_count_(new int(0)),
       ion_counter_(new std::atomic_size_t(0)),
-      thread_ion_counter_(0),
       abort_flag_(new std::atomic_bool()),
+      thread_ion_counter_(0),
       tally_mutex_(new std::mutex)
 {
 }
@@ -38,8 +38,8 @@ mccore::mccore(const mccore &s)
       tion_(s.tion_),
       ref_count_(s.ref_count_),
       ion_counter_(s.ion_counter_),
-      thread_ion_counter_(0),
       abort_flag_(s.abort_flag_),
+      thread_ion_counter_(0),
       tally_mutex_(s.tally_mutex_),
       dedx_calc_(s.dedx_calc_),
       flight_path_calc_(s.flight_path_calc_),
@@ -182,12 +182,12 @@ int mccore::reset()
     return 0;
 }
 
-void mccore::arm(size_t nions, size_t id0, size_t id_stride)
+void mccore::arm(size_t N, size_t id1, size_t id_stride)
 {
-    thread_ion_id_ = id0;
+    next_ion_id_ = id1;
     ion_id_stride_ = id_stride;
     thread_ion_counter_ = 0;
-    thread_max_no_ions_ = nions;
+    thread_max_no_ions_ = N;
     *abort_flag_ = false;
 }
 
@@ -205,15 +205,15 @@ int mccore::run()
     while (!(*abort_flag_) && thread_ion_counter_ < thread_max_no_ions_) {
 
         // get the ion id = 1-based index
-        size_t ion_id = thread_ion_id_ + 1;
+        size_t ion_id = next_ion_id_;
 
         // prepare id for the next ion
-        thread_ion_id_ += ion_id_stride_;
+        next_ion_id_ += ion_id_stride_;
 
         // increment thread counter
         thread_ion_counter_++;
 
-        // increment total ion counter
+        // increment shared total ion counter
         (*ion_counter_)++;
 
         // generate ion

--- a/source/lib/mccore.cpp
+++ b/source/lib/mccore.cpp
@@ -182,6 +182,15 @@ int mccore::reset()
     return 0;
 }
 
+void mccore::arm(size_t nions, size_t id0, size_t id_stride)
+{
+    thread_ion_id_ = id0;
+    ion_id_stride_ = id_stride;
+    thread_ion_counter_ = 0;
+    thread_max_no_ions_ = nions;
+    *abort_flag_ = false;
+}
+
 int mccore::run()
 {
     abstract_cascade *cscd = nullptr;
@@ -193,13 +202,19 @@ int mccore::run()
 
     bool cascadesOnly = par_.simulation_type == CascadesOnly;
 
-    while (!(*abort_flag_)) {
-        // get the next ion id
-        size_t ion_id = ion_counter_->fetch_add(1) + 1;
-        if (ion_id > max_no_ions_) {
-            (*ion_counter_)--;
-            break;
-        }
+    while (!(*abort_flag_) && thread_ion_counter_ < thread_max_no_ions_) {
+
+        // get the ion id = 1-based index
+        size_t ion_id = thread_ion_id_ + 1;
+
+        // prepare id for the next ion
+        thread_ion_id_ += ion_id_stride_;
+
+        // increment thread counter
+        thread_ion_counter_++;
+
+        // increment total ion counter
+        (*ion_counter_)++;
 
         // generate ion
         ion *i = ion_queue_.create_ion();
@@ -323,9 +338,6 @@ int mccore::run()
         tion_.clear();
         for (int i = 0; i < utally_.size(); ++i)
             ution_[i]->clear();
-
-        // update thread counter
-        thread_ion_counter_++;
 
     } // ion loop
 

--- a/source/lib/mccore.cpp
+++ b/source/lib/mccore.cpp
@@ -587,6 +587,21 @@ void mccore::mergeEvents(mccore &other)
     other.damage_stream_.clear();
 }
 
+void mccore::mergeEvents(std::vector<mccore *> &other)
+{
+    int n = other.size();
+    std::vector<event_stream *> streams(other.size());
+    for (int i = 0; i < n; ++i)
+        streams[i] = &(other[i]->pka_stream_);
+    pka_stream_.merge(streams);
+    for (int i = 0; i < n; ++i)
+        streams[i] = &(other[i]->exit_stream_);
+    exit_stream_.merge(streams);
+    for (int i = 0; i < n; ++i)
+        streams[i] = &(other[i]->damage_stream_);
+    damage_stream_.merge(streams);
+}
+
 ArrayNDd mccore::getTallyTable(int i) const
 {
     if (i < 0 || i >= tally::tEnd)

--- a/source/lib/mcdriver.cpp
+++ b/source/lib/mcdriver.cpp
@@ -102,7 +102,7 @@ int mcdriver::exec(progress_callback cb, size_t msInterval, void *callback_user_
     // cpu time
     struct timespec t_start, t_end;
 
-    int nthreads = config_.Run.threads;
+    size_t nthreads = config_.Run.threads;
     if (nthreads < 1) {
         nthreads = std::thread::hardware_concurrency();
         if (nthreads <= 3)
@@ -121,6 +121,9 @@ int mcdriver::exec(progress_callback cb, size_t msInterval, void *callback_user_
     if (n_end <= n_start)
         return -1;
 
+    // ions to run
+    size_t n_run = n_end - n_start;
+
     // check cpu time limit
     double tlim = std::numeric_limits<double>::max();
     if (config_.Run.max_cpu_time) {
@@ -135,12 +138,12 @@ int mcdriver::exec(progress_callback cb, size_t msInterval, void *callback_user_
 
     // create simulation clones
     sim_clones_.resize(nthreads);
-    for (int i = 0; i < nthreads; i++)
+    for (size_t i = 0; i < nthreads; i++)
         sim_clones_[i] = new mccore(*s_);
 
     // jump the rng's of clones (except the 1st one)
-    for (int i = 1; i < nthreads; i++) {
-        for (int j = 0; j < i; ++j)
+    for (size_t i = 1; i < nthreads; i++) {
+        for (size_t j = 0; j < i; ++j)
             sim_clones_[i]->rngJump();
     }
 
@@ -154,7 +157,7 @@ int mcdriver::exec(progress_callback cb, size_t msInterval, void *callback_user_
         ev_mask |= static_cast<uint32_t>(Event::Vacancy);
 
     // open clone streams
-    for (int i = 0; i < nthreads; i++)
+    for (size_t i = 0; i < nthreads; i++)
         sim_clones_[i]->init_streams(ev_mask);
 
     // If ion_count == 0, i.e. simulation starts,
@@ -162,15 +165,16 @@ int mcdriver::exec(progress_callback cb, size_t msInterval, void *callback_user_
     if (s_->ion_count() == 0)
         s_->init_streams(ev_mask);
 
-    // set max ions in each thread
-    for (int i = 0; i < nthreads; i++)
-        sim_clones_[i]->setMaxIons(n_end);
-
-    // clear the abort flag
-    s_->clear_abort_flag();
+    // arm the clones
+    // each clone runs N/nthread ions +1 if i < N % nthread
+    for (size_t i = 0; i < nthreads; i++) {
+        size_t id0 = s_->ion_count() + i;
+        size_t n_thread = (n_run / nthreads) + (i < (n_run % nthreads) ? 1 : 0);
+        sim_clones_[i]->arm(n_thread, id0, nthreads);
+    }
 
     // create & start worker threads
-    for (int i = 0; i < nthreads; i++)
+    for (size_t i = 0; i < nthreads; i++)
         thread_pool_.emplace_back(&mccore::run, sim_clones_[i]);
 
     // waiting loop
@@ -190,7 +194,7 @@ int mcdriver::exec(progress_callback cb, size_t msInterval, void *callback_user_
         // report progress if callback function is given
         if (cb) {
             // consolidate results
-            for (int i = 0; i < nthreads; i++)
+            for (size_t i = 0; i < nthreads; i++)
                 s_->mergeTallies(*(sim_clones_[i]));
             // callback
             cb(*this, callback_user_data);

--- a/source/lib/mcdriver.cpp
+++ b/source/lib/mcdriver.cpp
@@ -203,14 +203,15 @@ int mcdriver::exec(progress_callback cb, size_t msInterval, void *callback_user_
     } while ((s_->ion_count() < n_end) && !(s_->abort_flag()));
 
     // wait for threads to finish...
-    for (int i = 0; i < nthreads; i++)
+    for (size_t i = 0; i < nthreads; i++)
         thread_pool_[i].join();
 
-    // consolidate tallies & events
-    for (int i = 0; i < nthreads; i++) {
+    // consolidate tallies
+    for (size_t i = 0; i < nthreads; i++) {
         s_->mergeTallies(*(sim_clones_[i]));
-        s_->mergeEvents(*(sim_clones_[i]));
     }
+    // consolidate events, ordered per history id
+    s_->mergeEvents(sim_clones_);
 
     // report progress for the last time
     if (cb) {

--- a/source/lib/mcdriver.cpp
+++ b/source/lib/mcdriver.cpp
@@ -168,9 +168,9 @@ int mcdriver::exec(progress_callback cb, size_t msInterval, void *callback_user_
     // arm the clones
     // each clone runs N/nthread ions +1 if i < N % nthread
     for (size_t i = 0; i < nthreads; i++) {
-        size_t id0 = s_->ion_count() + i;
+        size_t id1 = n_start + i + 1;
         size_t n_thread = (n_run / nthreads) + (i < (n_run % nthreads) ? 1 : 0);
-        sim_clones_[i]->arm(n_thread, id0, nthreads);
+        sim_clones_[i]->arm(n_thread, id1, nthreads);
     }
 
     // create & start worker threads
@@ -205,6 +205,61 @@ int mcdriver::exec(progress_callback cb, size_t msInterval, void *callback_user_
     // wait for threads to finish...
     for (size_t i = 0; i < nthreads; i++)
         thread_pool_[i].join();
+
+    // if the actual total ion count is less than the expected
+    // (due to the simulation being aborted by the user or due to
+    // the time limit reached)
+    // we have to check if we have all consequtive ion history ids
+    if (s_->ion_count() < n_end) {
+
+        // update the last ion count (n_end) and
+        // the # of ions run in this exec()
+        n_end = s_->ion_count();
+        n_run = n_end - n_start;
+
+        // get the last ion ID in each thread
+        std::vector<size_t> ids(nthreads);
+        for (size_t i = 0; i < nthreads; i++)
+            ids[i] = sim_clones_[i]->thread_ion_count() ? sim_clones_[i]->next_ion_id() - nthreads
+                                                        : size_t(-1);
+
+        // get the max ID and the thread index where it occured
+        auto max_it = std::max_element(ids.begin(), ids.end());
+        int i = std::distance(ids.begin(), max_it);
+        size_t maxId = *max_it;
+
+        // if maxID > n_end => missing IDs
+        if (maxId > n_end) {
+            // how many
+            size_t n_missing = maxId - n_end;
+            // check all other threads (except the one with maxID) to find the missing
+            // traverse the threads from i(maxID) backwards
+            for (int k = 0; k < nthreads - 1; ++k) {
+                // update the thread index
+                i--;
+                if (i < 0)
+                    i += nthreads;
+                // this should be the i-th thread maxID
+                maxId--;
+                // check if the last id is below that
+                while ((ids[i] < maxId || ids[i] == size_t(-1)) && n_missing) {
+                    if (ids[i] == size_t(-1)) {
+                        ids[i] = n_start + i + 1;
+                    } else
+                        ids[i] += nthreads;
+                    // simulate 1 missing ion
+                    sim_clones_[i]->arm(1, ids[i], nthreads);
+                    sim_clones_[i]->run();
+                    n_missing--;
+                }
+                if (!n_missing)
+                    break;
+            }
+            assert(!n_missing);
+        } else {
+            assert(maxId == n_end);
+        }
+    }
 
     // consolidate tallies
     for (size_t i = 0; i < nthreads; i++) {


### PR DESCRIPTION
## Summary

   Fixes #24 — results were non-reproducible in multi-threaded runs because threads raced on a
   shared atomic counter to claim ion history IDs, making the mapping from thread → RNG sequence
   non-deterministic.

   - **Pre-assign ion IDs per thread**: each thread is now `arm()`-ed with a fixed starting ID and
   stride (`id1 = n_start + thread_index + 1`, `stride = nthreads`), so thread *i* always simulates
   histories `i+1, i+1+N, i+1+2N, …`. The shared atomic counter is no longer used for ID allocation.
   - **Order-preserving event stream merge**: added `event_stream::merge(vector<event_stream*>)`
   that merges events from all threads in ion-history-ID order. Merged event log is always in canonical order regardless of thread scheduling.
   - **Complete missing IDs after early abort**: when the simulation is stopped early (user abort or
    CPU time limit), some threads may have run further ahead than others, leaving gaps in the ID
   sequence. The driver now detects and fills any gaps by re-running the missing individual
   histories on the appropriate thread clone.
   - **Reproducibility documentation**: added `doc/reproducibility.md` explaining that results are
   reproducible given the same seed, ion count, *and* thread count.

   ## Tests performed

   - [X] Run the same simulation twice with a fixed seed and `threads > 1`; verify `h5diff` reports
   no differences between outputs
   - [X] Verify single-threaded reproducibility is unaffected
   - [X] Run with a CPU time limit / early abort and confirm the output contains a contiguous set of
    ion histories with no gaps
  
