### PR TITLE
build: pybind11 via FetchContent + bindings/python/ module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 option (OPENTRIM_BUILD_GUI "build gui" ON)
 option (OPENTRIM_BUILD_TESTS "build tests" ON)
+option (OPENTRIM_BUILD_PYTHON "Build Python bindings" ON)
 
 string(TIMESTAMP CMAKE_BUILD_TIME UTC)
 
@@ -61,6 +62,10 @@ if(OPENTRIM_BUILD_GUI)
 endif () ## BUILD GUI
 
 add_subdirectory(source)
+
+if (OPENTRIM_BUILD_PYTHON)
+    add_subdirectory(bindings/python)
+endif()
 
 if (OPENTRIM_BUILD_TESTS)
     add_subdirectory(test/scattering_calc)

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -1,0 +1,44 @@
+# Python bindings for OpenTRIM using pybind11.
+# pybind11 is fetched via FetchContent in cmake/Externals.cmake.
+# Links against the opentrim library target - no Qt dependency.
+
+pybind11_add_module(_opentrim_core MODULE
+    bindings.cpp
+)
+
+target_link_libraries(_opentrim_core PRIVATE
+    opentrim
+)
+
+target_include_directories(_opentrim_core PRIVATE
+    ${PROJECT_SOURCE_DIR}/source/include
+)
+
+if(SKBUILD)
+    # For Python installs, place OpenTRIM's private shared libraries next to
+    # the extension module and use $ORIGIN so the dynamic loader finds them.
+    # libdedx and HDF5 remain external runtime dependencies.
+    set_target_properties(_opentrim_core PROPERTIES
+        INSTALL_RPATH "$ORIGIN"
+    )
+    set_target_properties(opentrim PROPERTIES
+        BUILD_RPATH  "$ORIGIN;$<TARGET_FILE_DIR:libdedx::dedx>"
+        INSTALL_RPATH "$ORIGIN;$<TARGET_FILE_DIR:libdedx::dedx>"
+    )
+
+    install(TARGETS _opentrim_core DESTINATION opentrim)
+    install(FILES
+        $<TARGET_FILE:opentrim>
+        $<TARGET_FILE:xs_zbl>
+        $<TARGET_FILE:xs_bohr>
+        $<TARGET_FILE:xs_krc>
+        $<TARGET_FILE:xs_moliere>
+        DESTINATION opentrim
+    )
+    install(FILES opentrim/__init__.py DESTINATION opentrim)
+else()
+    # Plain CMake build: libopentrim and xs_* are installed by
+    # source/lib/CMakeLists.txt. _opentrim_core uses the global RPATH.
+    install(TARGETS _opentrim_core DESTINATION opentrim)
+    install(FILES opentrim/__init__.py DESTINATION opentrim)
+endif()

--- a/bindings/python/bindings.cpp
+++ b/bindings/python/bindings.cpp
@@ -1,0 +1,23 @@
+#include <pybind11/pybind11.h>
+
+#include "mcdriver.h"
+
+namespace py = pybind11;
+
+// Forward declarations - implemented in separate translation units (added per PR)
+// void bind_enums(py::module_&);   // A-2
+// void bind_config(py::module_&);  // A-2
+// void bind_driver(py::module_&);  // A-3
+// void bind_info(py::module_&);    // A-4
+
+PYBIND11_MODULE(_opentrim_core, m)
+{
+    m.doc() = "Python bindings for the OpenTRIM Monte Carlo ion transport simulator";
+    m.attr("__version__") = mcdriver::version_info().version;
+
+    // Registration calls added per PR:
+    // bind_enums(m);   // A-2
+    // bind_config(m);  // A-2
+    // bind_driver(m);  // A-3
+    // bind_info(m);    // A-4
+}

--- a/bindings/python/opentrim/__init__.py
+++ b/bindings/python/opentrim/__init__.py
@@ -1,0 +1,3 @@
+from ._opentrim_core import __version__
+
+__all__ = ["__version__"]

--- a/cmake/CMakeSummary.cmake
+++ b/cmake/CMakeSummary.cmake
@@ -24,6 +24,7 @@ opentrim_print_var(CMAKE_INSTALL_PREFIX)
 opentrim_print_var(CMAKE_INSTALL_RPATH)
 opentrim_print_var(OPENTRIM_BUILD_GUI)
 opentrim_print_var(OPENTRIM_BUILD_TESTS)
+opentrim_print_var(OPENTRIM_BUILD_PYTHON)
 
 message(STATUS "Found dependencies:")
 

--- a/cmake/Externals.cmake
+++ b/cmake/Externals.cmake
@@ -115,4 +115,15 @@ if(PACKAGE_BUILD)
 endif()
 FetchContent_MakeAvailable(external_ieee754_seq)
 
-
+if(OPENTRIM_BUILD_PYTHON)
+   FetchContent_Declare(external_pybind11
+      GIT_REPOSITORY https://github.com/pybind/pybind11.git
+      GIT_TAG        v3.0.4
+      GIT_SUBMODULES_RECURSE FALSE
+      GIT_SHALLOW    TRUE
+   )
+   if(PACKAGE_BUILD)
+      set(FETCHCONTENT_SOURCE_DIR_EXTERNAL_PYBIND11 ${PROJECT_SOURCE_DIR}/external/ext10)
+   endif()
+   FetchContent_MakeAvailable(external_pybind11)
+endif()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires      = ["scikit-build-core>=0.11", "pybind11>=3.0"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name             = "opentrim"
+version          = "1.1.2"
+requires-python  = ">=3.9"
+description      = "Python bindings for the OpenTRIM Monte Carlo ion transport simulator"
+dependencies     = ["numpy>=1.21"]
+
+[project.optional-dependencies]
+jupyter = ["ipython", "matplotlib"]
+
+[tool.scikit-build]
+cmake.args = [
+    "-DOPENTRIM_BUILD_GUI=OFF",
+    "-DOPENTRIM_BUILD_TESTS=OFF",
+    "-DOPENTRIM_BUILD_PYTHON=ON",
+]


### PR DESCRIPTION
build: pybind11 via FetchContent + bindings/python module skeleton

Delivers A-1 from the GSoC2026 Python bindings plan.

## What this adds

- `OPENTRIM_BUILD_PYTHON` CMake option (default ON)
- pybind11 v3.0.4 fetched via FetchContent
- `bindings/python/` directory with `_opentrim_core` extension module skeleton
- `pyproject.toml` for pip installs via scikit-build-core
- Under SKBUILD: co-installs `libopentrim` and `xs_*` into the Python package dir with `$ORIGIN` RPATH so private libs resolve from `site-packages/opentrim/`
- `__version__` reads from `mcdriver::version_info()`, giving the extension a real runtime dependency on libopentrim
- CMake summary prints `OPENTRIM_BUILD_PYTHON`

## Tested

Ubuntu 24.04, Python 3.12:

```bash
pip install -e . --no-build-isolation
python -c "import opentrim; print(opentrim.__version__)"
# 1.1.2