### PR TITLE
feat: bind Info results tree and complete Config reprs (A-4)

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -7,6 +7,7 @@ pybind11_add_module(_opentrim_core MODULE
     enums_bind.cpp
     config_bind.cpp
     driver_bind.cpp
+    info_bind.cpp
 )
 
 target_link_libraries(_opentrim_core PRIVATE

--- a/bindings/python/bindings.cpp
+++ b/bindings/python/bindings.cpp
@@ -8,7 +8,7 @@ namespace py = pybind11;
 void bind_enums(py::module_&);
 void bind_config(py::module_&);
 void bind_driver(py::module_&);
-// void bind_info(py::module_&);
+void bind_info(py::module_&);
 
 PYBIND11_MODULE(_opentrim_core, m)
 {
@@ -18,5 +18,5 @@ PYBIND11_MODULE(_opentrim_core, m)
     bind_enums(m);
     bind_config(m); // keep before bind_driver - Driver.init()/config() use Config
     bind_driver(m);
-    // bind_info(m);
+    bind_info(m); // keep after bind_driver - Info(driver) consumes a Driver
 }

--- a/bindings/python/config_bind.cpp
+++ b/bindings/python/config_bind.cpp
@@ -30,6 +30,26 @@ PYBIND11_MAKE_OPAQUE(std::vector<user_tally::parameters>)
 
 namespace py = pybind11;
 
+// formats a vector3 / ivector3 as "[x, y, z]" for __repr__ output
+static std::string vec3_str(const vector3& v)
+{
+    return "[" + std::to_string(v.x()) + ", " + std::to_string(v.y()) + ", "
+            + std::to_string(v.z()) + "]";
+}
+static std::string ivec3_str(const ivector3& v)
+{
+    return "[" + std::to_string(v.x()) + ", " + std::to_string(v.y()) + ", "
+            + std::to_string(v.z()) + "]";
+}
+
+// looks up the Python name of a bound enum value (e.g. FullCascade) so __repr__
+// prints the symbol rather than a raw integer.
+template <typename E>
+std::string enum_name(E value)
+{
+    return py::cast(value).attr("name").template cast<std::string>();
+}
+
 // adds __getitem__ / __setitem__ so any bound struct supports dict-style access
 template <typename T>
 void bind_dict_access(py::class_<T>& cls)
@@ -69,7 +89,11 @@ void bind_config(py::module_& m)
         .def_property("xzvector",
             [](const coord_sys& c) { return c.xzvector; },
             [](coord_sys& c, const vector3& v) { c.xzvector = v; },
-            "A vector in the xz-plane used to define the x-axis.");
+            "A vector in the xz-plane used to define the x-axis.")
+        .def("__repr__", [](const coord_sys& c) {
+            return "CoordSys(zaxis=" + vec3_str(c.zaxis)
+                   + ", origin=" + vec3_str(c.origin) + ")";
+        });
     bind_dict_access(cs_cls);
 
     py::class_<atom::parameters> atom_cls(m, "Atom",
@@ -171,7 +195,32 @@ void bind_config(py::module_& m)
         .def_readwrite("Tdam",     &user_tally::bin_var_t::Tdam,     "PKA damage energy bin edges [eV].")
         .def_readwrite("V",        &user_tally::bin_var_t::V,        "Vacancy count bin edges.")
         .def_readwrite("atom_id",  &user_tally::bin_var_t::atom_id,  "Atom species id bin edges.")
-        .def_readwrite("recoil_id",&user_tally::bin_var_t::recoil_id,"Recoil generation id bin edges.");
+        .def_readwrite("recoil_id",&user_tally::bin_var_t::recoil_id,"Recoil generation id bin edges.")
+        .def("__repr__", [](const user_tally::bin_var_t& b) {
+            // list only the axes that actually have bin edges defined
+            std::vector<std::string> ax;
+            if (!b.x.empty())         ax.push_back("x");
+            if (!b.y.empty())         ax.push_back("y");
+            if (!b.z.empty())         ax.push_back("z");
+            if (!b.r.empty())         ax.push_back("r");
+            if (!b.rho.empty())       ax.push_back("rho");
+            if (!b.cosTheta.empty())  ax.push_back("cosTheta");
+            if (!b.nx.empty())        ax.push_back("nx");
+            if (!b.ny.empty())        ax.push_back("ny");
+            if (!b.nz.empty())        ax.push_back("nz");
+            if (!b.E.empty())         ax.push_back("E");
+            if (!b.Tdam.empty())      ax.push_back("Tdam");
+            if (!b.V.empty())         ax.push_back("V");
+            if (!b.atom_id.empty())   ax.push_back("atom_id");
+            if (!b.recoil_id.empty()) ax.push_back("recoil_id");
+            std::string s = "UserTallyBins(";
+            if (ax.empty())
+                s += "empty";
+            else
+                for (size_t i = 0; i < ax.size(); ++i)
+                    s += (i ? ", " : "") + ax[i];
+            return s + ")";
+        });
     bind_dict_access(bins_cls);
 
     py::class_<user_tally::parameters> utally_cls(m, "UserTally",
@@ -219,7 +268,11 @@ void bind_config(py::module_& m)
                        "NRT vacancy method (NRT_Impl).")
         .def_readwrite("intra_cascade_recombination",
                        &mccore::parameters::intra_cascade_recombination,
-                       "Allow intra-cascade Frenkel pair recombination.");
+                       "Allow intra-cascade Frenkel pair recombination.")
+        .def("__repr__", [](const mccore::parameters& s) {
+            return "SimulationParams(simulation_type=" + enum_name(s.simulation_type)
+                   + ", electronic_stopping=" + enum_name(s.electronic_stopping) + ")";
+        });
     bind_dict_access(sim_cls);
 
     py::class_<mccore::transport_options> tr_cls(m, "TransportParams",
@@ -254,7 +307,11 @@ void bind_config(py::module_& m)
                 t.mfp_range[0] = v[0];
                 t.mfp_range[1] = v[1];
             },
-            "MFP limits [min, max] in atomic radii.");
+            "MFP limits [min, max] in atomic radii.")
+        .def("__repr__", [](const mccore::transport_options& t) {
+            return "TransportParams(flight_path_type=" + enum_name(t.flight_path_type)
+                   + ", min_energy=" + std::to_string(t.min_energy) + ")";
+        });
     bind_dict_access(tr_cls);
 
 
@@ -267,7 +324,11 @@ void bind_config(py::module_& m)
         .def_readwrite("center", &ion_beam::energy_distribution_t::center,
                        "Mean energy [eV].")
         .def_readwrite("fwhm",   &ion_beam::energy_distribution_t::fwhm,
-                       "FWHM of energy distribution [eV].");
+                       "FWHM of energy distribution [eV].")
+        .def("__repr__", [](const ion_beam::energy_distribution_t& e) {
+            return "EnergyDistribution(type=" + enum_name(e.type)
+                   + ", center=" + std::to_string(e.center) + " eV)";
+        });
     bind_dict_access(edist_cls);
 
     
@@ -284,7 +345,11 @@ void bind_config(py::module_& m)
         .def_property("center",
             [](const ion_beam::spatial_distribution_t& s) { return s.center; },
             [](ion_beam::spatial_distribution_t& s, const vector3& v) { s.center = v; },
-            "Mean starting position [x, y, z] in nm.");
+            "Mean starting position [x, y, z] in nm.")
+        .def("__repr__", [](const ion_beam::spatial_distribution_t& s) {
+            return "SpatialDistribution(geometry=" + enum_name(s.geometry)
+                   + ", type=" + enum_name(s.type) + ")";
+        });
     bind_dict_access(sdist_cls);
 
     py::class_<ion_beam::angular_distribution_t> adist_cls(m, "AngularDistribution",
@@ -298,7 +363,11 @@ void bind_config(py::module_& m)
             [](ion_beam::angular_distribution_t& a, const vector3& v) { a.center = v; },
             "Mean beam direction (unnormalized).  Default: [1, 0, 0] = along +x.")
         .def_readwrite("fwhm", &ion_beam::angular_distribution_t::fwhm,
-                       "Angular spread FWHM [sr].");
+                       "Angular spread FWHM [sr].")
+        .def("__repr__", [](const ion_beam::angular_distribution_t& a) {
+            return "AngularDistribution(type=" + enum_name(a.type)
+                   + ", center=" + vec3_str(a.center) + ")";
+        });
     bind_dict_access(adist_cls);
 
     py::class_<ion_beam::parameters> ib_cls(m, "IonBeamParams",
@@ -312,7 +381,11 @@ void bind_config(py::module_& m)
         .def_readwrite("spatial_distribution", &ion_beam::parameters::spatial_distribution,
                        "Spatial distribution (SpatialDistribution).")
         .def_readwrite("angular_distribution", &ion_beam::parameters::angular_distribution,
-                       "Angular distribution (AngularDistribution).");
+                       "Angular distribution (AngularDistribution).")
+        .def("__repr__", [](const ion_beam::parameters& p) {
+            return "IonBeamParams(ion=" + p.ion.symbol
+                   + ", E0=" + std::to_string(p.energy_distribution.center) + " eV)";
+        });
     bind_dict_access(ib_cls);
 
     py::class_<target::target_desc_t> tgt_cls(m, "TargetParams",
@@ -342,7 +415,13 @@ void bind_config(py::module_& m)
         .def_readwrite("materials", &target::target_desc_t::materials,
                        "List of Material objects (MaterialList).")
         .def_readwrite("regions",   &target::target_desc_t::regions,
-                       "List of Region objects (RegionList).");
+                       "List of Region objects (RegionList).")
+        .def("__repr__", [](const target::target_desc_t& t) {
+            return "TargetParams(size=" + vec3_str(t.size)
+                   + ", cell_count=" + ivec3_str(t.cell_count)
+                   + ", materials=" + std::to_string(t.materials.size())
+                   + ", regions=" + std::to_string(t.regions.size()) + ")";
+        });
     bind_dict_access(tgt_cls);
 
     py::class_<mcconfig::run_options> run_cls(m, "RunOptions",

--- a/bindings/python/info_bind.cpp
+++ b/bindings/python/info_bind.cpp
@@ -1,0 +1,236 @@
+/*
+ * info_bind.cpp
+ *
+ * Binds opentrim.Info - the read side of the API.
+ *
+ * mcinfo is a self-describing tree: every node carries a type, a description,
+ * child nodes, and typed getter lambdas that pull live data from the driver at
+ * query time.  Rather than bind one Python attribute per result, we bind the
+ * generic node once.  keys() / __getitem__ then walk the whole tree, so any
+ * key mcinfo.cpp adds in the future shows up in Python with no change here.
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "driver_bind.h"
+#include "mcinfo.h"
+
+namespace py = pybind11;
+
+namespace {
+
+const char *type_name(mcinfo::info_t t)
+{
+    switch (t) {
+    case mcinfo::group: return "group";
+    case mcinfo::string: return "string";
+    case mcinfo::json: return "json";
+    case mcinfo::real64: return "real64";
+    case mcinfo::real32: return "real32";
+    case mcinfo::uint64: return "uint64";
+    case mcinfo::tally_score: return "tally_score";
+    default: return "invalid";
+    }
+}
+
+// build an owning numpy array shaped by dim.  mcinfo returns copies, so Python
+// never holds a pointer into C++ memory.
+template <class T>
+py::array_t<T> make_array(const std::vector<T> &v, const mcinfo::dim_t &dim)
+{
+    std::vector<py::ssize_t> shape(dim.begin(), dim.end());
+
+    size_t n = 1;
+    for (size_t d : dim)
+        n *= d;
+    // fall back to a flat shape if the reported dim does not match the data -
+    // better a correct 1-D array than a buffer overrun on the memcpy.
+    if (n != v.size())
+        shape = { (py::ssize_t)v.size() };
+
+    py::array_t<T> arr(shape);
+    if (!v.empty())
+        std::memcpy(arr.mutable_data(), v.data(), v.size() * sizeof(T));
+    return arr;
+}
+
+// mcinfo does not flag whether a string node holds one value or a list, and a
+// single-element list looks identical to a scalar (both report dim {1}).  these
+// are the string leaves that are genuinely scalar in mcinfo.cpp; everything else
+// (material names, atom symbols, bin names, ...) is a list, even with one entry.
+// a future is_scalar flag on mcinfo would make this lookup unnecessary.
+bool is_scalar_string_key(const std::string &key)
+{
+    static const std::unordered_set<std::string> scalar_keys = {
+        "title", "json_config", "run_history", "version", "git_tag", "compiler",
+        "compiler_version", "build_system", "build_time", "decription", "event",
+        "event_decription"
+    };
+    return scalar_keys.count(key) != 0;
+}
+
+// read a leaf node's value.  groups are handled by __getitem__ and never reach
+// here.  key is the node's own name, used only to tell scalar strings from lists.
+py::object leaf_value(const mcinfo &n, const std::string &key)
+{
+    mcinfo::dim_t dim;
+    switch (n.type()) {
+    case mcinfo::string:
+    case mcinfo::json: {
+        std::vector<std::string> s;
+        n.get(s, dim);
+        // json is always a single document; named scalar fields collapse to a
+        // plain str.  list-valued fields stay a list even with one element.
+        if (n.type() == mcinfo::json || is_scalar_string_key(key))
+            return py::str(s.empty() ? std::string() : s[0]);
+        py::list out;
+        for (const auto &x : s)
+            out.append(py::str(x));
+        return out;
+    }
+    case mcinfo::real64: {
+        std::vector<double> s;
+        n.get(s, dim);
+        return make_array(s, dim);
+    }
+    case mcinfo::real32: {
+        std::vector<float> s;
+        n.get(s, dim);
+        return make_array(s, dim);
+    }
+    case mcinfo::uint64: {
+        std::vector<uint64_t> s;
+        n.get(s, dim);
+        return make_array(s, dim);
+    }
+    case mcinfo::tally_score: {
+        // tally data is returned as (values, sem) - both normalized per ion.
+        std::vector<double> s, ds;
+        if (!n.get(s, ds, dim))
+            throw std::runtime_error("tally data unavailable; run the simulation first");
+        return py::make_tuple(make_array(s, dim), make_array(ds, dim));
+    }
+    default:
+        throw std::runtime_error("info node has no readable value");
+    }
+}
+
+// walk the static tree structure for __repr__.  this reads node metadata only
+// (type, name, children) and never calls a getter, so it has no side effects and
+// is safe to call even while a simulation is running.
+void repr_tree(const mcinfo &n, const std::string &prefix, std::string &out)
+{
+    const auto &kids = n.children();
+    size_t i = 0, last = kids.size();
+    for (const auto &kv : kids) {
+        bool is_last = (++i == last);
+        out += prefix;
+        out += is_last ? "\xe2\x94\x94\xe2\x94\x80\xe2\x94\x80 " // "└── "
+                       : "\xe2\x94\x9c\xe2\x94\x80\xe2\x94\x80 "; // "├── "
+        out += kv.first;
+        out += " [";
+        out += type_name(kv.second.type());
+        out += "]\n";
+        if (kv.second.type() == mcinfo::group)
+            repr_tree(kv.second, prefix + (is_last ? "    " : "\xe2\x94\x82   "), out);
+    }
+}
+
+std::string render_tree(const mcinfo &n)
+{
+    std::string out = "Info [";
+    out += type_name(n.type());
+    out += "]\n";
+    repr_tree(n, "", out);
+    return out;
+}
+
+} // namespace
+
+void bind_info(py::module_ &m)
+{
+    py::class_<mcinfo> info(m, "Info",
+        "Read-only view of simulation results.  Wraps the C++ mcinfo tree.\n\n"
+        "    info = opentrim.Info(sim)            # sim is an initialized Driver\n"
+        "    v, dv = info[\"tally\"][\"damage_events\"][\"Vacancies\"]\n\n"
+        "Tally nodes return (values, sem) numpy tuples normalized per ion.\n"
+        "Note: reading results while a Mode A run is in progress may race;\n"
+        "prefer calling sim.wait() first.");
+
+    info.def(py::init([](py::object driver_obj) {
+                 DriverWrapper &w = driver_obj.cast<DriverWrapper &>();
+                 // mcinfo's constructor dereferences getSim() (mcinfo.cpp:442),
+                 // so the driver must be initialized before we build the tree.
+                 if (!w.driver().getSim())
+                     throw std::runtime_error(
+                             "driver not initialized; call init(config) before Info(driver)");
+                 return new mcinfo(&w.driver());
+             }),
+             py::arg("driver"),
+             // keep the Driver alive as long as this Info exists - mcinfo holds a
+             // raw mcdriver* and reads through it on every access.
+             py::keep_alive<1, 2>(),
+             "Build an Info view over an initialized Driver.");
+
+    info.def("keys",
+             [](const mcinfo &n) {
+                 std::vector<std::string> k;
+                 for (const auto &kv : n.children())
+                     k.push_back(kv.first);
+                 return k;
+             },
+             "Available keys at this level, in definition order.");
+
+    info.def("__getitem__",
+             [](py::object self, const std::string &key) -> py::object {
+                 const mcinfo &node = self.cast<const mcinfo &>();
+                 // mcinfo::operator[] silently inserts on a missing key
+                 // (mcinfo.h:42), so look it up through children().at() instead.
+                 const mcinfo *child;
+                 try {
+                     child = &node.children().at(key);
+                 } catch (const std::out_of_range &) {
+                     throw py::key_error(key);
+                 }
+                 if (child->type() == mcinfo::group)
+                     // return the sub-node, tied to this Info's lifetime.
+                     return py::cast(child, py::return_value_policy::reference_internal, self);
+                 return leaf_value(*child, key);
+             },
+             py::arg("key"),
+             "Return a sub-Info for a group, or the value for a leaf node.");
+
+    info.def("__contains__",
+             [](const mcinfo &n, const std::string &key) {
+                 return n.children().find(key) != n.children().end();
+             });
+
+    info.def("__len__", [](const mcinfo &n) { return n.children().size(); });
+
+    info.def("__iter__",
+             [](py::object self) { return py::iter(self.attr("keys")()); });
+
+    info.def_property_readonly(
+            "type", [](const mcinfo &n) { return std::string(type_name(n.type())); },
+            "Node type: group, string, json, real64, real32, uint64, or tally_score.");
+
+    info.def_property_readonly(
+            "description", [](const mcinfo &n) { return n.description(); },
+            "Human-readable description of this node.");
+
+    info.def_static("info_spec", []() { return mcinfo::info_spec(); },
+                    "Return the JSON spec of the full info tree structure.");
+
+    // structural tree only - reads node metadata, never calls a getter, so it has
+    // no side effects and is safe to print even while a simulation is running.
+    info.def("__repr__", [](const mcinfo &n) { return render_tree(n); });
+    info.def("__str__", [](const mcinfo &n) { return render_tree(n); });
+}

--- a/bindings/python/opentrim/__init__.py
+++ b/bindings/python/opentrim/__init__.py
@@ -31,6 +31,7 @@ from ._opentrim_core import (
     OutputOptions,
     Config,
     Driver,
+    Info,
 )
 
 __all__ = [
@@ -66,4 +67,5 @@ __all__ = [
     "OutputOptions",
     "Config",
     "Driver",
+    "Info",
 ]


### PR DESCRIPTION
 Delivers A-4 from the GSoC2026 Feature-A Python bindings plan.

  ## What this adds
  - `opentrim.Info` wrapping the `mcinfo` results tree - one generic node binding, so every key in mcinfo.cpp is reachable from Python (`keys()`, `info["..."]`, `.type`, `.description`, `Info.info_spec()`)
  - tally nodes return `(values, sem)` numpy tuples normalized per ion; arrays are copies, never views into C++ memory
  - `Info` keeps its `Driver` alive via `keep_alive` + `reference_internal` (mcinfo holds a raw `const mcdriver*` and reads through it on every access)
  - guards: `Info(driver)` before `init()` raises (the mcinfo constructor dereferences `getSim()`); a missing key raises `KeyError` instead of `mcinfo::operator[]` silently inserting a node
  - structural `__repr__` prints the full key tree without evaluating getters, so it stays safe to call mid-run
  - `__repr__` on the nine remaining Config sub-structs so `repr(config.Simulation)` etc. read cleanly in notebooks (mcdriver.h / mccore.cpp / mcinfo.h untouched)

  ## Tested
Ubuntu 24.04, Python 3.12 - built and exercised locally: full key-tree walk, tally `(data, sem)` shapes `[Natoms, Nx, Ny, Nz]` and totals `[18, Natoms]`, grid/atoms/materials reads, single-element list fields stay lists, scalar strings stay str, KeyError on bad key, and the Info-before-init guard. `__repr_html__` and the formal pytest suite arrive in A-5.
