### PR TITLE
feat: 3D track data pipeline via event handler (B-1)

### DIFF
--- a/source/gui/CMakeLists.txt
+++ b/source/gui/CMakeLists.txt
@@ -19,9 +19,11 @@ set(GUI_HEADERS
     simcontrolwidget.h 
     tabularview.h
     value_with_error.h
-    jsedit/jsedit.h 
+    jsedit/jsedit.h
     simboxview.h
     mcplotinfo.h
+    cascadeassembler.h
+    trackdatachannel.h
 )
 
 set(GUI_SOURCES
@@ -43,6 +45,8 @@ set(GUI_SOURCES
     jsedit/jsedit.cpp
     simboxview.cpp
     mcplotinfo.cpp
+    cascadeassembler.cpp
+    trackdatachannel.cpp
 )
 
 set (GUI_TARGET ${PROJECT_NAME_LOWERCASE}-gui)

--- a/source/gui/cascadeassembler.cpp
+++ b/source/gui/cascadeassembler.cpp
@@ -1,0 +1,113 @@
+#include "cascadeassembler.h"
+
+#include <cassert>
+#include <climits>
+
+#include <ion.h>
+#include <target.h>
+
+uint32_t CascadeAssembler::eventMask()
+{
+    return static_cast<uint32_t>(Event::NewSourceIon) | static_cast<uint32_t>(Event::NewRecoil)
+            | static_cast<uint32_t>(Event::Scattering) | static_cast<uint32_t>(Event::IonStop)
+            | static_cast<uint32_t>(Event::IonExit) | static_cast<uint32_t>(Event::Replacement);
+}
+
+CascadeAssembler::CascadeAssembler(sink_t sink) : sink_(std::move(sink)) { }
+
+void CascadeAssembler::feed(Event ev, const ion &i)
+{
+    switch (ev) {
+    case Event::NewSourceIon:
+        // a new source ion closes the previous history
+        if (inCascade_)
+            handoff();
+        waitBoundary_ = false;
+        beginCascade();
+        beginTrack(i);
+        break;
+
+    case Event::NewRecoil:
+        if (waitBoundary_ || !inCascade_)
+            break;
+        endTrack();
+        beginTrack(i);
+        break;
+
+    case Event::Scattering:
+        if (waitBoundary_ || !inTrack_)
+            break;
+        addVertex(i);
+        break;
+
+    case Event::IonStop:
+    case Event::IonExit:
+    case Event::Replacement:
+        if (waitBoundary_ || !inTrack_)
+            break;
+        addVertex(i);
+        endTrack();
+        break;
+
+    default:
+        break;
+    }
+}
+
+void CascadeAssembler::flush()
+{
+    if (inCascade_)
+        handoff();
+}
+
+void CascadeAssembler::reset()
+{
+    current_ = Cascade();
+    inCascade_ = false;
+    inTrack_ = false;
+    waitBoundary_ = true;
+}
+
+void CascadeAssembler::beginCascade()
+{
+    current_ = Cascade();
+    inCascade_ = true;
+    inTrack_ = false;
+}
+
+void CascadeAssembler::beginTrack(const ion &i)
+{
+    current_.tracks.emplace_back();
+    inTrack_ = true;
+    addVertex(i);
+}
+
+void CascadeAssembler::addVertex(const ion &i)
+{
+    if (!inTrack_ || current_.tracks.empty())
+        return;
+
+    const vector3 &r = i.pos();
+    const atom *a = i.myAtom();
+    assert(i.recoil_id() <= INT16_MAX && (!a || a->id() <= INT16_MAX));
+
+    TrackVertex v;
+    v.x = r.x();
+    v.y = r.y();
+    v.z = r.z();
+    v.energy = static_cast<float>(i.erg());
+    v.t = static_cast<float>(i.t());
+    v.rid = static_cast<int16_t>(i.recoil_id());
+    v.aid = static_cast<int16_t>(a ? a->id() : 0);
+
+    current_.tracks.back().verts.push_back(v);
+}
+
+void CascadeAssembler::handoff()
+{
+    if (!current_.tracks.empty() && sink_)
+        sink_(std::move(current_));
+    current_ = Cascade();
+    inCascade_ = false;
+    inTrack_ = false;
+}

--- a/source/gui/cascadeassembler.cpp
+++ b/source/gui/cascadeassembler.cpp
@@ -216,16 +216,13 @@ void CascadeAssembler::applyEvent(const RawEvent &r)
 
     case State::InTrack:
         switch (r.ev) {
-        case Event::NewSourceIon:
-            // new ion_id = next history; same ion_id = replacement continuation
+        case Event::NewSourceIon: // fires once per source ion (core source flag)
             endTrack();
-            if (r.ion_id != cascadeIonId_) {
-                handoff();
-                beginCascade(r.ion_id);
-            }
+            handoff();
+            beginCascade(r.ion_id);
             beginTrack(r.v);
             break;
-        case Event::NewRecoil: // recoils share the history's ion_id
+        case Event::NewRecoil:
             endTrack();
             beginTrack(r.v);
             break;
@@ -247,10 +244,8 @@ void CascadeAssembler::applyEvent(const RawEvent &r)
     case State::BetweenTracks:
         switch (r.ev) {
         case Event::NewSourceIon:
-            if (r.ion_id != cascadeIonId_) {
-                handoff();
-                beginCascade(r.ion_id);
-            }
+            handoff();
+            beginCascade(r.ion_id);
             beginTrack(r.v);
             state_ = State::InTrack;
             break;
@@ -269,7 +264,6 @@ void CascadeAssembler::beginCascade(uint64_t id)
 {
     current_ = Cascade();
     current_.id = id;
-    cascadeIonId_ = id;
     track_start_ = 0;
     current_.buff.reserve(kCascadeReserve);
 }

--- a/source/gui/cascadeassembler.cpp
+++ b/source/gui/cascadeassembler.cpp
@@ -6,6 +6,14 @@
 #include <ion.h>
 #include <target.h>
 
+// ~10 MB raw buffers (40 B/record), ~25 hand-offs/s at the ~230 MB/s peak. 4
+// buffers give one buffer of slack so the consumer can jitter without dropping.
+static const size_t kBufferRecords = 262144;
+static const size_t kNumBuffers = 4;
+
+// typical vertices per cascade; a larger one grows once (on the consumer thread)
+static const size_t kCascadeReserve = 65536;
+
 uint32_t CascadeAssembler::eventMask()
 {
     return static_cast<uint32_t>(Event::NewSourceIon) | static_cast<uint32_t>(Event::NewRecoil)
@@ -13,101 +21,278 @@ uint32_t CascadeAssembler::eventMask()
             | static_cast<uint32_t>(Event::IonExit) | static_cast<uint32_t>(Event::Replacement);
 }
 
-CascadeAssembler::CascadeAssembler(sink_t sink) : sink_(std::move(sink)) { }
+CascadeAssembler::CascadeAssembler(sink_t sink) : sink_(std::move(sink))
+{
+    pool_.reserve(kNumBuffers);
+    for (size_t k = 0; k < kNumBuffers; ++k) {
+        std::unique_ptr<RawBuffer> b(new RawBuffer());
+        b->data.resize(kBufferRecords); // the only per-buffer allocation, done once
+        pool_.push_back(std::move(b));
+    }
+    cur_ = pool_[0].get();
+    for (size_t k = 1; k < kNumBuffers; ++k)
+        free_.push(pool_[k].get());
+
+    consumer_ = std::thread(&CascadeAssembler::consumeLoop, this);
+}
+
+CascadeAssembler::~CascadeAssembler()
+{
+    {
+        std::lock_guard<std::mutex> lk(mtx_); // set stop_ under the lock: no lost wakeup
+        stop_.store(true, std::memory_order_relaxed);
+    }
+    cvReady_.notify_all();
+    if (consumer_.joinable())
+        consumer_.join();
+}
+
+// -------------------- producer (simulation thread) --------------------
+
+CascadeAssembler::RawBuffer *CascadeAssembler::acquireFree()
+{
+    std::lock_guard<std::mutex> lk(mtx_);
+    if (free_.empty())
+        return nullptr;
+    return free_.pop();
+}
+
+void CascadeAssembler::publishReady(RawBuffer *b)
+{
+    {
+        std::lock_guard<std::mutex> lk(mtx_);
+        ready_.push(b);
+    }
+    cvReady_.notify_one();
+}
 
 void CascadeAssembler::feed(Event ev, const ion &i)
 {
-    switch (ev) {
-    case Event::NewSourceIon:
-        // a new source ion closes the previous history
-        if (inCascade_)
-            handoff();
-        waitBoundary_ = false;
-        beginCascade();
-        beginTrack(i);
-        break;
+    if (!capturing_.load(std::memory_order_relaxed)) {
+        // publish the partial buffer so a resume starts on a fresh, resync'd buffer
+        if (cur_ != nullptr && cur_->count > 0) {
+            publishReady(cur_);
+            cur_ = nullptr;
+        }
+        sawGap_ = true;
+        return;
+    }
 
-    case Event::NewRecoil:
-        if (waitBoundary_ || !inCascade_)
-            break;
-        endTrack();
-        beginTrack(i);
-        break;
+    if (cur_ == nullptr) {
+        cur_ = acquireFree();
+        if (cur_ == nullptr) { // consumer behind: drop, resync at the next cascade
+            dropped_.fetch_add(1, std::memory_order_relaxed);
+            sawGap_ = true;
+            return;
+        }
+        cur_->resyncBefore = sawGap_;
+        sawGap_ = false;
+    }
 
-    case Event::Scattering:
-        if (waitBoundary_ || !inTrack_)
-            break;
-        addVertex(i);
-        break;
+    // copy the event fields by index - no allocation
+    assert(cur_->count < cur_->data.size());
+    RawEvent &slot = cur_->data[cur_->count];
+    slot.ev = ev;
+    slot.ion_id = static_cast<uint64_t>(i.ion_id()); // ion_id() is int today; store 64-bit
+    const vector3 &r = i.pos();
+    const atom *a = i.myAtom();
+    assert(i.recoil_id() <= INT16_MAX && (!a || a->id() <= INT16_MAX));
+    slot.v.x = r.x();
+    slot.v.y = r.y();
+    slot.v.z = r.z();
+    slot.v.energy = static_cast<float>(i.erg());
+    slot.v.t = static_cast<float>(i.t());
+    slot.v.rid = static_cast<int16_t>(i.recoil_id());
+    slot.v.aid = static_cast<int16_t>(a ? a->id() : 0);
+    ++cur_->count;
 
-    case Event::IonStop:
-    case Event::IonExit:
-    case Event::Replacement:
-        if (waitBoundary_ || !inTrack_)
-            break;
-        addVertex(i);
-        endTrack();
-        break;
-
-    default:
-        break;
+    if (cur_->count == cur_->data.size()) {
+        publishReady(cur_);
+        cur_ = acquireFree();
+        if (cur_ != nullptr) {
+            cur_->resyncBefore = sawGap_;
+            sawGap_ = false;
+        } else {
+            sawGap_ = true;
+        }
     }
 }
 
 void CascadeAssembler::flush()
 {
-    if (inCascade_)
-        handoff();
+    // publish the partial buffer (or return it empty), then let the consumer
+    // drain and close the tail cascade. Called after the sim thread has stopped.
+    if (cur_ != nullptr) {
+        if (cur_->count > 0) {
+            cur_->resyncBefore = sawGap_;
+            publishReady(cur_);
+        } else {
+            std::lock_guard<std::mutex> lk(mtx_);
+            free_.push(cur_);
+        }
+        cur_ = nullptr;
+        sawGap_ = false;
+    }
+
+    std::unique_lock<std::mutex> lk(mtx_);
+    finalizeDone_ = false;
+    // if capture is off the tail belongs to an interrupted window: drop it
+    finalizeDiscard_ = !capturing_.load(std::memory_order_relaxed);
+    finalize_ = true;
+    cvReady_.notify_one();
+    cvFinalize_.wait(lk, [this] { return finalizeDone_; });
 }
 
-void CascadeAssembler::reset()
+// -------------------- consumer thread --------------------
+
+void CascadeAssembler::consumeLoop()
+{
+    for (;;) {
+        RawBuffer *b = nullptr;
+        bool doFinalize = false;
+        bool discard = false;
+        {
+            std::unique_lock<std::mutex> lk(mtx_);
+            cvReady_.wait(lk, [this] {
+                return stop_.load(std::memory_order_relaxed) || !ready_.empty() || finalize_;
+            });
+            if (!ready_.empty()) {
+                b = ready_.pop(); // process buffers before honoring finalize/stop
+            } else if (finalize_) {
+                finalize_ = false;
+                doFinalize = true;
+                discard = finalizeDiscard_;
+            } else {
+                return; // stop_ and nothing left
+            }
+        }
+
+        if (b != nullptr) {
+            processBuffer(b);
+            std::lock_guard<std::mutex> lk(mtx_);
+            b->count = 0;
+            b->resyncBefore = false;
+            free_.push(b);
+        } else if (doFinalize) {
+            if (discard) {
+                current_ = Cascade(); // capture was off: drop the interrupted cascade
+            } else {
+                if (state_ == State::InTrack)
+                    endTrack();
+                if (state_ == State::InTrack || state_ == State::BetweenTracks)
+                    handoff();
+            }
+            state_ = State::WaitForIon; // re-arm for a possible next run
+            {
+                std::lock_guard<std::mutex> lk(mtx_);
+                finalizeDone_ = true;
+            }
+            cvFinalize_.notify_all();
+        }
+    }
+}
+
+void CascadeAssembler::processBuffer(RawBuffer *b)
+{
+    if (b->resyncBefore) { // a gap in the stream: drop the partial cascade
+        current_ = Cascade();
+        track_start_ = 0;
+        state_ = State::WaitForIon;
+    }
+    for (size_t k = 0; k < b->count; ++k)
+        applyEvent(b->data[k]);
+}
+
+void CascadeAssembler::applyEvent(const RawEvent &r)
+{
+    switch (state_) {
+    case State::WaitForIon:
+        if (r.ev == Event::NewSourceIon) {
+            beginCascade(r.ion_id);
+            beginTrack(r.v);
+            state_ = State::InTrack;
+        }
+        break;
+
+    case State::InTrack:
+        switch (r.ev) {
+        case Event::NewSourceIon:
+            // new ion_id = next history; same ion_id = replacement continuation
+            endTrack();
+            if (r.ion_id != cascadeIonId_) {
+                handoff();
+                beginCascade(r.ion_id);
+            }
+            beginTrack(r.v);
+            break;
+        case Event::NewRecoil: // recoils share the history's ion_id
+            endTrack();
+            beginTrack(r.v);
+            break;
+        case Event::Scattering:
+            addVertex(r.v);
+            break;
+        case Event::IonStop:
+        case Event::IonExit:
+        case Event::Replacement:
+            addVertex(r.v);
+            endTrack();
+            state_ = State::BetweenTracks;
+            break;
+        default:
+            break;
+        }
+        break;
+
+    case State::BetweenTracks:
+        switch (r.ev) {
+        case Event::NewSourceIon:
+            if (r.ion_id != cascadeIonId_) {
+                handoff();
+                beginCascade(r.ion_id);
+            }
+            beginTrack(r.v);
+            state_ = State::InTrack;
+            break;
+        case Event::NewRecoil:
+            beginTrack(r.v);
+            state_ = State::InTrack;
+            break;
+        default: // stray scattering or a deferred end with no open track
+            break;
+        }
+        break;
+    }
+}
+
+void CascadeAssembler::beginCascade(uint64_t id)
 {
     current_ = Cascade();
-    inCascade_ = false;
-    inTrack_ = false;
-    waitBoundary_ = true;
+    current_.id = id;
+    cascadeIonId_ = id;
+    track_start_ = 0;
+    current_.buff.reserve(kCascadeReserve);
 }
 
-void CascadeAssembler::beginCascade()
+void CascadeAssembler::beginTrack(const TrackVertex &v)
 {
-    current_ = Cascade();
-    inCascade_ = true;
-    inTrack_ = false;
+    track_start_ = static_cast<int32_t>(current_.buff.size());
+    addVertex(v);
 }
 
-void CascadeAssembler::beginTrack(const ion &i)
+void CascadeAssembler::endTrack()
 {
-    current_.tracks.emplace_back();
-    inTrack_ = true;
-    addVertex(i);
-}
-
-void CascadeAssembler::addVertex(const ion &i)
-{
-    if (!inTrack_ || current_.tracks.empty())
-        return;
-
-    const vector3 &r = i.pos();
-    const atom *a = i.myAtom();
-    assert(i.recoil_id() <= INT16_MAX && (!a || a->id() <= INT16_MAX));
-
-    TrackVertex v;
-    v.x = r.x();
-    v.y = r.y();
-    v.z = r.z();
-    v.energy = static_cast<float>(i.erg());
-    v.t = static_cast<float>(i.t());
-    v.rid = static_cast<int16_t>(i.recoil_id());
-    v.aid = static_cast<int16_t>(a ? a->id() : 0);
-
-    current_.tracks.back().verts.push_back(v);
+    int32_t len = static_cast<int32_t>(current_.buff.size()) - track_start_;
+    if (len > 0) {
+        current_.start_pos.push_back(track_start_);
+        current_.length.push_back(len);
+    }
 }
 
 void CascadeAssembler::handoff()
 {
-    if (!current_.tracks.empty() && sink_)
+    if (!current_.buff.empty() && sink_)
         sink_(std::move(current_));
     current_ = Cascade();
-    inCascade_ = false;
-    inTrack_ = false;
+    track_start_ = 0;
 }

--- a/source/gui/cascadeassembler.h
+++ b/source/gui/cascadeassembler.h
@@ -1,0 +1,62 @@
+#ifndef CASCADEASSEMBLER_H
+#define CASCADEASSEMBLER_H
+
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+#include <tally.h> // Event
+
+class ion;
+
+struct TrackVertex
+{
+    float x, y, z; // position [nm]
+    float energy; // [eV]
+    float t; // time [ns]
+    int16_t rid; // recoil generation (0 = source ion)
+    int16_t aid; // atom id
+};
+// 24 bytes, laid out to map directly onto the OpenGL vertex buffer
+static_assert(sizeof(TrackVertex) == 24, "TrackVertex must stay 24 bytes");
+
+struct Track
+{
+    std::vector<TrackVertex> verts;
+};
+
+struct Cascade
+{
+    std::vector<Track> tracks;
+};
+
+// Rebuilds cascades from the event stream (one source-ion history per cascade).
+// No Qt or OpenGL, so it can be tested on its own. feed() runs on the sim thread.
+class CascadeAssembler
+{
+public:
+    typedef std::function<void(Cascade &&)> sink_t;
+
+    static uint32_t eventMask();
+
+    explicit CascadeAssembler(sink_t sink);
+
+    void feed(Event ev, const ion &i);
+    void flush(); // hand off the cascade under construction
+    void reset(); // drop it and wait for the next boundary
+
+private:
+    void beginCascade();
+    void beginTrack(const ion &i);
+    void addVertex(const ion &i);
+    void endTrack() { inTrack_ = false; }
+    void handoff();
+
+    sink_t sink_;
+    Cascade current_;
+    bool inCascade_{ false };
+    bool inTrack_{ false };
+    bool waitBoundary_{ true };
+};
+
+#endif // CASCADEASSEMBLER_H

--- a/source/gui/cascadeassembler.h
+++ b/source/gui/cascadeassembler.h
@@ -1,8 +1,13 @@
 #ifndef CASCADEASSEMBLER_H
 #define CASCADEASSEMBLER_H
 
+#include <atomic>
+#include <condition_variable>
 #include <cstdint>
 #include <functional>
+#include <memory>
+#include <mutex>
+#include <thread>
 #include <vector>
 
 #include <tally.h> // Event
@@ -20,18 +25,18 @@ struct TrackVertex
 // 24 bytes, laid out to map directly onto the OpenGL vertex buffer
 static_assert(sizeof(TrackVertex) == 24, "TrackVertex must stay 24 bytes");
 
-struct Track
-{
-    std::vector<TrackVertex> verts;
-};
-
+// Contiguous layout for glMultiDrawArrays: all vertices in buff, plus the start
+// index and length of each track. start_pos/length are int32_t (GLint/GLsizei).
 struct Cascade
 {
-    std::vector<Track> tracks;
+    uint64_t id{ 0 }; // source-ion history id
+    std::vector<TrackVertex> buff;
+    std::vector<int32_t> start_pos;
+    std::vector<int32_t> length;
 };
 
-// Rebuilds cascades from the event stream (one source-ion history per cascade).
-// No Qt or OpenGL, so it can be tested on its own. feed() runs on the sim thread.
+// Builds cascades from the event stream. feed() (sim thread) copies events into a
+// fixed buffer; a consumer thread parses them into cascades, off the physics thread.
 class CascadeAssembler
 {
 public:
@@ -40,23 +45,93 @@ public:
     static uint32_t eventMask();
 
     explicit CascadeAssembler(sink_t sink);
+    ~CascadeAssembler();
 
+    // producer, simulation thread. Single producer only: install the handler on
+    // exactly one thread (install_event_handler thread_no).
     void feed(Event ev, const ion &i);
-    void flush(); // hand off the cascade under construction
-    void reset(); // drop it and wait for the next boundary
+    void flush(); // hand off the tail cascade; call after the run stopped
+
+    void setCapturing(bool on) { capturing_.store(on, std::memory_order_relaxed); }
+    bool isCapturing() const { return capturing_.load(std::memory_order_relaxed); }
+    uint64_t dropped() const { return dropped_.load(std::memory_order_relaxed); }
 
 private:
-    void beginCascade();
-    void beginTrack(const ion &i);
-    void addVertex(const ion &i);
-    void endTrack() { inTrack_ = false; }
+    struct RawEvent
+    {
+        Event ev;
+        uint64_t ion_id; // source-ion history id, delimits cascades
+        TrackVertex v;
+    };
+    static_assert(sizeof(RawEvent) == 40, "RawEvent must stay 40 bytes");
+
+    struct RawBuffer
+    {
+        std::vector<RawEvent> data; // fixed capacity, sized once at construction
+        size_t count{ 0 };
+        bool resyncBefore{ false }; // events were dropped before this buffer
+    };
+
+    // Fixed FIFO of buffer pointers (guarded by mtx_). Never allocates.
+    struct PtrRing
+    {
+        RawBuffer *slot[8];
+        int head{ 0 }, tail{ 0 }, n{ 0 };
+        bool empty() const { return n == 0; }
+        void push(RawBuffer *b)
+        {
+            slot[tail] = b;
+            tail = (tail + 1) & 7;
+            ++n;
+        }
+        RawBuffer *pop()
+        {
+            RawBuffer *b = slot[head];
+            head = (head + 1) & 7;
+            --n;
+            return b;
+        }
+    };
+
+    // ---- producer (simulation thread only) ----
+    RawBuffer *acquireFree();
+    void publishReady(RawBuffer *b);
+    RawBuffer *cur_{ nullptr };
+    bool sawGap_{ false }; // producer skipped/dropped events since the last buffer
+
+    // ---- consumer thread only ----
+    void consumeLoop();
+    void processBuffer(RawBuffer *b);
+    void applyEvent(const RawEvent &r);
+    void beginCascade(uint64_t id);
+    void beginTrack(const TrackVertex &v);
+    void addVertex(const TrackVertex &v) { current_.buff.push_back(v); }
+    void endTrack();
     void handoff();
 
-    sink_t sink_;
+    // WaitForIon: waiting for a NewSourceIon. InTrack: a track is open.
+    // BetweenTracks: cascade open, no track open.
+    enum class State { WaitForIon, InTrack, BetweenTracks };
+    State state_{ State::WaitForIon };
     Cascade current_;
-    bool inCascade_{ false };
-    bool inTrack_{ false };
-    bool waitBoundary_{ true };
+    int32_t track_start_{ 0 }; // first index of the open track in current_.buff
+    uint64_t cascadeIonId_{ 0 }; // ion_id of the cascade being built
+    sink_t sink_;
+
+    // ---- shared ----
+    std::vector<std::unique_ptr<RawBuffer>> pool_;
+    std::mutex mtx_;
+    std::condition_variable cvReady_; // consumer waits for a full buffer or stop
+    std::condition_variable cvFinalize_; // flush waits for the drained tail handoff
+    PtrRing free_;
+    PtrRing ready_;
+    std::atomic<bool> stop_{ false };
+    std::atomic<bool> capturing_{ false }; // pass-through until the view is active
+    std::atomic<uint64_t> dropped_{ 0 };
+    bool finalize_{ false };
+    bool finalizeDone_{ false };
+    bool finalizeDiscard_{ false }; // flush found capture off: drop the partial tail
+    std::thread consumer_;
 };
 
 #endif // CASCADEASSEMBLER_H

--- a/source/gui/cascadeassembler.h
+++ b/source/gui/cascadeassembler.h
@@ -60,7 +60,7 @@ private:
     struct RawEvent
     {
         Event ev;
-        uint64_t ion_id; // source-ion history id, delimits cascades
+        uint64_t ion_id; // source-ion history id (becomes Cascade.id)
         TrackVertex v;
     };
     static_assert(sizeof(RawEvent) == 40, "RawEvent must stay 40 bytes");
@@ -115,7 +115,6 @@ private:
     State state_{ State::WaitForIon };
     Cascade current_;
     int32_t track_start_{ 0 }; // first index of the open track in current_.buff
-    uint64_t cascadeIonId_{ 0 }; // ion_id of the cascade being built
     sink_t sink_;
 
     // ---- shared ----

--- a/source/gui/mcdriverobj.cpp
+++ b/source/gui/mcdriverobj.cpp
@@ -34,6 +34,13 @@ McDriverObj::~McDriverObj()
 {
 }
 
+void McDriverObj::setEventHandler(mccore::event_handler h, uint32_t mask, void *p)
+{
+    eventHandler_ = h;
+    eventMask_ = mask;
+    eventHandlerData_ = p;
+}
+
 const mcconfig &McDriverObj::options() const
 {
     return options_;
@@ -329,6 +336,10 @@ void McDriverObj::start(bool b)
             opt.Run.threads = nThreads_;
 
             driver_ = mcdriver::create(opt);
+
+            // install the track viewer handler, if one was registered
+            if (eventHandler_)
+                driver_->install_event_handler(eventHandler_, eventMask_, eventHandlerData_, 0);
 
             info_.clear();
 

--- a/source/gui/mcdriverobj.h
+++ b/source/gui/mcdriverobj.h
@@ -90,6 +90,9 @@ public:
     // get sim title
     QString title() const;
 
+    // register a handler to install on the driver (see install_event_handler)
+    void setEventHandler(mccore::event_handler h, uint32_t mask, void *p);
+
     // validate sim options
     // error msgs are optionally returned in msg pointer
     bool validateOptions(QString *msg = nullptr) const;
@@ -177,6 +180,10 @@ private:
     std::shared_ptr<mcdriver> driver_;
     std::shared_ptr<mcdriver> test_driver_;
     mcconfig options_;
+
+    mccore::event_handler eventHandler_{ nullptr };
+    uint32_t eventMask_{ 0 };
+    void *eventHandlerData_{ nullptr };
     bool modified_;
     bool template_;
     QString fileName_;

--- a/source/gui/trackdatachannel.cpp
+++ b/source/gui/trackdatachannel.cpp
@@ -7,19 +7,7 @@ TrackDataChannel::TrackDataChannel(QObject *parent)
 
 void TrackDataChannel::onEvent(Event ev, const ion &i, void *p)
 {
-    static_cast<TrackDataChannel *>(p)->dispatch(ev, i);
-}
-
-void TrackDataChannel::dispatch(Event ev, const ion &i)
-{
-    // reset on any change of the capture flag, so we start on a clean boundary
-    const bool want = capturing_.load(std::memory_order_relaxed);
-    if (want != active_) {
-        active_ = want;
-        assembler_.reset();
-    }
-    if (active_)
-        assembler_.feed(ev, i);
+    static_cast<TrackDataChannel *>(p)->assembler_.feed(ev, i);
 }
 
 void TrackDataChannel::enqueue(Cascade &&c)
@@ -42,6 +30,5 @@ std::vector<std::shared_ptr<const Cascade>> TrackDataChannel::takeCascades()
 
 void TrackDataChannel::flush()
 {
-    // called after the run stops, so the assembler is no longer in use
     assembler_.flush();
 }

--- a/source/gui/trackdatachannel.cpp
+++ b/source/gui/trackdatachannel.cpp
@@ -1,0 +1,47 @@
+#include "trackdatachannel.h"
+
+TrackDataChannel::TrackDataChannel(QObject *parent)
+    : QObject(parent), assembler_([this](Cascade &&c) { enqueue(std::move(c)); })
+{
+}
+
+void TrackDataChannel::onEvent(Event ev, const ion &i, void *p)
+{
+    static_cast<TrackDataChannel *>(p)->dispatch(ev, i);
+}
+
+void TrackDataChannel::dispatch(Event ev, const ion &i)
+{
+    // reset on any change of the capture flag, so we start on a clean boundary
+    const bool want = capturing_.load(std::memory_order_relaxed);
+    if (want != active_) {
+        active_ = want;
+        assembler_.reset();
+    }
+    if (active_)
+        assembler_.feed(ev, i);
+}
+
+void TrackDataChannel::enqueue(Cascade &&c)
+{
+    {
+        std::lock_guard<std::mutex> lock(mtx_);
+        ready_.push_back(std::make_shared<const Cascade>(std::move(c)));
+    }
+    emit cascadeReady();
+}
+
+std::vector<std::shared_ptr<const Cascade>> TrackDataChannel::takeCascades()
+{
+    std::vector<std::shared_ptr<const Cascade>> out;
+    std::lock_guard<std::mutex> lock(mtx_);
+    out.assign(ready_.begin(), ready_.end());
+    ready_.clear();
+    return out;
+}
+
+void TrackDataChannel::flush()
+{
+    // called after the run stops, so the assembler is no longer in use
+    assembler_.flush();
+}

--- a/source/gui/trackdatachannel.h
+++ b/source/gui/trackdatachannel.h
@@ -1,7 +1,6 @@
 #ifndef TRACKDATACHANNEL_H
 #define TRACKDATACHANNEL_H
 
-#include <atomic>
 #include <deque>
 #include <memory>
 #include <mutex>
@@ -11,8 +10,9 @@
 
 #include "cascadeassembler.h"
 
-// Carries ion track data from the simulation thread (thread-0 handler) to the
-// GUI thread: finished cascades are queued and drained with takeCascades().
+// Carries track data from the sim thread to the GUI thread. Finished cascades are
+// queued and cascadeReady() is emitted from the consumer thread (so B-2 must use a
+// queued connection); the GUI thread drains with takeCascades().
 class TrackDataChannel : public QObject
 {
     Q_OBJECT
@@ -26,26 +26,23 @@ public:
 
     std::vector<std::shared_ptr<const Cascade>> takeCascades();
 
-    bool isCapturing() const { return capturing_.load(std::memory_order_relaxed); }
+    bool isCapturing() const { return assembler_.isCapturing(); }
 
 public slots:
-    void setCapturing(bool on) { capturing_.store(on, std::memory_order_relaxed); }
+    void setCapturing(bool on) { assembler_.setCapturing(on); }
     void flush(); // call after the run has stopped
 
 signals:
     void cascadeReady();
 
 private:
-    void dispatch(Event ev, const ion &i); // simulation thread only
-    void enqueue(Cascade &&c); // simulation thread only
-
-    CascadeAssembler assembler_;
-    bool active_{ false }; // simulation-thread view of capturing_
-
-    std::atomic_bool capturing_{ false };
+    void enqueue(Cascade &&c); // runs on the assembler's consumer thread
 
     std::mutex mtx_;
     std::deque<std::shared_ptr<const Cascade>> ready_;
+
+    // declared last: its consumer thread is joined before ready_/mtx_ are destroyed
+    CascadeAssembler assembler_;
 };
 
 #endif // TRACKDATACHANNEL_H

--- a/source/gui/trackdatachannel.h
+++ b/source/gui/trackdatachannel.h
@@ -1,0 +1,51 @@
+#ifndef TRACKDATACHANNEL_H
+#define TRACKDATACHANNEL_H
+
+#include <atomic>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include <QObject>
+
+#include "cascadeassembler.h"
+
+// Carries ion track data from the simulation thread (thread-0 handler) to the
+// GUI thread: finished cascades are queued and drained with takeCascades().
+class TrackDataChannel : public QObject
+{
+    Q_OBJECT
+public:
+    static uint32_t eventMask() { return CascadeAssembler::eventMask(); }
+
+    // the handler; p is a TrackDataChannel*
+    static void onEvent(Event ev, const ion &i, void *p);
+
+    explicit TrackDataChannel(QObject *parent = nullptr);
+
+    std::vector<std::shared_ptr<const Cascade>> takeCascades();
+
+    bool isCapturing() const { return capturing_.load(std::memory_order_relaxed); }
+
+public slots:
+    void setCapturing(bool on) { capturing_.store(on, std::memory_order_relaxed); }
+    void flush(); // call after the run has stopped
+
+signals:
+    void cascadeReady();
+
+private:
+    void dispatch(Event ev, const ion &i); // simulation thread only
+    void enqueue(Cascade &&c); // simulation thread only
+
+    CascadeAssembler assembler_;
+    bool active_{ false }; // simulation-thread view of capturing_
+
+    std::atomic_bool capturing_{ false };
+
+    std::mutex mtx_;
+    std::deque<std::shared_ptr<const Cascade>> ready_;
+};
+
+#endif // TRACKDATACHANNEL_H

--- a/source/include/ion.h
+++ b/source/include/ion.h
@@ -106,6 +106,7 @@ private:
     size_t ion_id_; // ion history id
     int recoil_id_; // recoil id (generation), 0=ion, 1=PKA, ...
     size_t uid_; // unique recoil id
+    bool source_ion_; // true for source generated ions
     const atom *atom_;
     const grid3D *grid_;
 
@@ -172,10 +173,21 @@ public:
     int prev_cellid() const { return prev_cellid_; }
 
     /// Returns the history id that the current ion belongs to
-    int ion_id() const { return ion_id_; }
+    size_t ion_id() const { return ion_id_; }
 
     /// set history id
     void setId(size_t id) { ion_id_ = id; }
+
+    /// set source flag
+    void setSource() { source_ion_ = true; }
+
+    /// reset source flag and return its value
+    bool source_test_and_reset()
+    {
+        bool ret = source_ion_;
+        source_ion_ = false;
+        return ret;
+    }
 
     /**
      * @brief Returns the recoil generation id of the current ion

--- a/source/lib/ion.cpp
+++ b/source/lib/ion.cpp
@@ -71,6 +71,7 @@ ion::ion()
       prev_cellid_(-1),
       ion_id_(0),
       recoil_id_(0),
+      source_ion_(false),
       atom_(nullptr),
       grid_(nullptr),
       ncoll_(0),

--- a/source/lib/mccore.cpp
+++ b/source/lib/mccore.cpp
@@ -224,6 +224,7 @@ int mccore::run()
         // generate ion
         ion *i = ion_queue_.create_ion();
         i->setId(ion_id);
+        i->setSource();
         i->setRecoilId(cascadesOnly ? 1 : 0);
         i->reset_counters();
         source_->source_ion(rng, *target_, *i);
@@ -369,7 +370,7 @@ int mccore::transport(ion *i)
         flight_path_calc_.preload(i, mat);
     }
 
-    handle_event(i->recoil_id() ? Event::NewRecoil : Event::NewSourceIon, *i);
+    handle_event(i->source_test_and_reset() ? Event::NewSourceIon : Event::NewRecoil, *i);
 
     // transport loop
     while (1) {

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -18,14 +18,24 @@ target_link_libraries(test_scattering_calc
     xs_moliere
 )
 
-add_executable(test_event_handling 
+add_executable(test_event_handling
     test_event_handling.cpp
+    ${CMAKE_SOURCE_DIR}/source/gui/cascadeassembler.cpp
 )
 
-target_include_directories(test_event_handling 
+target_include_directories(test_event_handling
 PRIVATE
     ${CMAKE_SOURCE_DIR}/source/include
+    ${CMAKE_SOURCE_DIR}/source/gui
 )
+
+target_compile_definitions(test_event_handling
+PRIVATE
+    CONFIG_JSON="${CMAKE_SOURCE_DIR}/test/opentrim/b1.json"
+)
+
 target_link_libraries(test_event_handling
     opentrim
 )
+
+add_test(NAME event_handling COMMAND test_event_handling)

--- a/test/cpp/test_event_handling.cpp
+++ b/test/cpp/test_event_handling.cpp
@@ -1,0 +1,141 @@
+// Event handler API + track assembly test (Feature B, B-1).
+
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+#include "mcdriver.h"
+
+#include "cascadeassembler.h"
+
+struct counters
+{
+    int source = 0, recoil = 0, scatter = 0, ended = 0, other = 0;
+};
+
+struct probe
+{
+    counters c;
+    std::vector<Cascade> cascades;
+    CascadeAssembler assembler;
+
+    probe() : assembler([this](Cascade &&x) { cascades.push_back(std::move(x)); }) { }
+};
+
+static void probe_handler(Event ev, const ion &i, void *p)
+{
+    probe &pr = *static_cast<probe *>(p);
+    switch (ev) {
+    case Event::NewSourceIon:
+        pr.c.source++;
+        break;
+    case Event::NewRecoil:
+        pr.c.recoil++;
+        break;
+    case Event::Scattering:
+        pr.c.scatter++;
+        break;
+    case Event::IonStop:
+    case Event::IonExit:
+    case Event::Replacement:
+        pr.c.ended++;
+        break;
+    default:
+        pr.c.other++;
+        break;
+    }
+    pr.assembler.feed(ev, i);
+}
+
+static std::shared_ptr<mcdriver> make_driver(size_t nions, int nthreads)
+{
+    mcconfig cfg;
+    std::ifstream is(CONFIG_JSON);
+    if (!is.is_open()) {
+        std::cerr << "cannot open " << CONFIG_JSON << std::endl;
+        return nullptr;
+    }
+    if (cfg.parseJSON(is, true, &std::cerr) != 0)
+        return nullptr;
+    cfg.Run.max_no_ions = nions;
+    cfg.Run.threads = nthreads;
+    return mcdriver::create(cfg, &std::cerr);
+}
+
+#define CHECK(cond)                                                                                 \
+    do {                                                                                            \
+        if (!(cond)) {                                                                              \
+            std::cerr << "FAILED: " #cond " (line " << __LINE__ << ")" << std::endl;                \
+            return 1;                                                                               \
+        }                                                                                           \
+    } while (0)
+
+static int check_probe(const char *tag, probe &pr)
+{
+    pr.assembler.flush();
+
+    size_t tracks = 0, verts = 0;
+    for (const auto &cc : pr.cascades) {
+        CHECK(!cc.tracks.empty());
+        CHECK(!cc.tracks.front().verts.empty());
+        CHECK(cc.tracks.front().verts.front().rid == 0);
+        for (const auto &t : cc.tracks) {
+            CHECK(!t.verts.empty());
+            tracks += 1;
+            verts += t.verts.size();
+        }
+    }
+    std::cout << tag << ": source=" << pr.c.source << " recoil=" << pr.c.recoil
+              << " scatter=" << pr.c.scatter << " end=" << pr.c.ended << " other=" << pr.c.other
+              << " | cascades=" << pr.cascades.size() << " tracks=" << tracks << " verts=" << verts
+              << std::endl;
+
+    CHECK(pr.c.source > 0);
+    CHECK(pr.c.recoil > 0);
+    CHECK(pr.c.scatter > 0);
+    CHECK(pr.c.other == 0);
+    CHECK(pr.c.source + pr.c.recoil == pr.c.ended);
+    CHECK(pr.cascades.size() == (size_t)pr.c.source);
+    CHECK(tracks == (size_t)(pr.c.source + pr.c.recoil));
+    CHECK(verts > 0);
+    return 0;
+}
+
+int main()
+{
+    // single thread
+    {
+        auto D = make_driver(30, 1);
+        CHECK(D);
+        probe pr;
+        CHECK(D->install_event_handler(probe_handler, CascadeAssembler::eventMask(), &pr, 0));
+        D->exec(nullptr, 200);
+        if (check_probe("single", pr))
+            return 1;
+    }
+
+    // no handler: the run must be untouched
+    {
+        auto D = make_driver(30, 1);
+        CHECK(D);
+        D->exec(nullptr, 200);
+        CHECK(!D->run_history().empty());
+        size_t ran = D->run_history().back().total_ion_count;
+        std::cout << "transparency: requested=30 ran=" << ran << std::endl;
+        CHECK(ran > 0);
+    }
+
+    // 4 threads, more ions
+    {
+        auto D = make_driver(200, 4);
+        CHECK(D);
+        probe pr;
+        CHECK(D->install_event_handler(probe_handler, CascadeAssembler::eventMask(), &pr, 0));
+        D->exec(nullptr, 200);
+        if (check_probe("stress", pr))
+            return 1;
+    }
+
+    std::cout << "ALL PASS" << std::endl;
+    return 0;
+}

--- a/test/cpp/test_event_handling.cpp
+++ b/test/cpp/test_event_handling.cpp
@@ -70,12 +70,12 @@ static std::shared_ptr<mcdriver> make_driver(size_t nions, int nthreads)
     return mcdriver::create(cfg, &std::cerr);
 }
 
-#define CHECK(cond)                                                                                 \
-    do {                                                                                            \
-        if (!(cond)) {                                                                              \
-            std::cerr << "FAILED: " #cond " (line " << __LINE__ << ")" << std::endl;                \
-            return 1;                                                                               \
-        }                                                                                           \
+#define CHECK(cond)                                                                  \
+    do {                                                                             \
+        if (!(cond)) {                                                               \
+            std::cerr << "FAILED: " #cond " (line " << __LINE__ << ")" << std::endl; \
+            return 1;                                                                \
+        }                                                                            \
     } while (0)
 
 static int check_probe(const char *tag, probe &pr)
@@ -157,31 +157,51 @@ int main()
 
     // 4. recording overhead: the same run with capture off vs on
     {
-        typedef std::chrono::steady_clock clock;
+        int Nions = 1000; // enough to measure ms
+        std::cout << "Testing capture overhead: " << Nions << " ions, 1 thread" << std::endl;
 
+        // case 0 : no handler at all
+        std::cout << "  running without handler: ...";
+        std::cout.flush();
+        auto D00 = make_driver(Nions, 1);
+        CHECK(D00);
+        D00->exec(nullptr, 200);
+        double ms_none = D00->run_history().back().cpu_time_s * 1000.0 / Nions; // convert to ms/ion
+        std::cout << "done." << std::endl;
+
+        std::cout << "  running with handler, capture off: ...";
+        std::cout.flush();
         probe off; // capture stays off (default)
-        auto D0 = make_driver(50, 1);
+        auto D0 = make_driver(Nions, 1);
         CHECK(D0);
         CHECK(D0->install_event_handler(probe_handler, CascadeAssembler::eventMask(), &off, 0));
-        clock::time_point t0 = clock::now();
         D0->exec(nullptr, 200);
-        double ms_off = std::chrono::duration<double, std::milli>(clock::now() - t0).count();
+        double ms_off = D0->run_history().back().cpu_time_s * 1000.0 / Nions;
+        std::cout << "done." << std::endl;
 
+        std::cout << "  running with handler, capture on: ...";
+        std::cout.flush();
         probe on;
         on.assembler.setCapturing(true);
-        auto D1 = make_driver(50, 1);
+        auto D1 = make_driver(Nions, 1);
         CHECK(D1);
         CHECK(D1->install_event_handler(probe_handler, CascadeAssembler::eventMask(), &on, 0));
-        t0 = clock::now();
         D1->exec(nullptr, 200);
-        double ms_on = std::chrono::duration<double, std::milli>(clock::now() - t0).count();
+        double ms_on = D1->run_history().back().cpu_time_s * 1000.0 / Nions;
+        std::cout << "done." << std::endl;
 
         off.assembler.flush();
         on.assembler.flush();
 
-        std::cout << "timing(50 ions): off=" << ms_off << "ms on=" << ms_on
-                  << "ms overhead=" << (ms_on - ms_off) << "ms dropped=" << on.assembler.dropped()
+        double off_overhead = int((ms_off - ms_none) / ms_none * 1000) / 10.0; // round to 0.1%
+        double on_overhead = int((ms_on - ms_none) / ms_none * 1000) / 10.0; // round to 0.1%
+        std::cout << "timing(" << Nions << " ions):" << std::endl;
+        std::cout << "  no handler:  " << ms_none << " ms/ion" << std::endl;
+        std::cout << "  capture off: " << ms_off << " ms/ion, overhead=" << off_overhead << "%"
                   << std::endl;
+        std::cout << "  capture on:  " << ms_on << " ms/ion, overhead=" << on_overhead << "%"
+                  << std::endl;
+
         CHECK(off.cascades.empty()); // capture off: nothing recorded
         CHECK(!on.cascades.empty()); // capture on: cascades recorded
     }

--- a/test/cpp/test_event_handling.cpp
+++ b/test/cpp/test_event_handling.cpp
@@ -1,7 +1,9 @@
 // Event handler API + track assembly test (Feature B, B-1).
 
+#include <chrono>
 #include <fstream>
 #include <iostream>
+#include <set>
 #include <vector>
 
 #include "mcdriver.h"
@@ -16,8 +18,11 @@ struct counters
 struct probe
 {
     counters c;
+    std::set<uint64_t> ids; // distinct source-ion history ids
+    int disableAt{ -1 }; // event index at which to turn capture off (-1 = never)
+    int seen{ 0 };
     std::vector<Cascade> cascades;
-    CascadeAssembler assembler;
+    CascadeAssembler assembler; // last: joined before cascades/ids on destruction
 
     probe() : assembler([this](Cascade &&x) { cascades.push_back(std::move(x)); }) { }
 };
@@ -28,6 +33,7 @@ static void probe_handler(Event ev, const ion &i, void *p)
     switch (ev) {
     case Event::NewSourceIon:
         pr.c.source++;
+        pr.ids.insert(static_cast<uint64_t>(i.ion_id()));
         break;
     case Event::NewRecoil:
         pr.c.recoil++;
@@ -45,6 +51,8 @@ static void probe_handler(Event ev, const ion &i, void *p)
         break;
     }
     pr.assembler.feed(ev, i);
+    if (pr.disableAt >= 0 && ++pr.seen == pr.disableAt)
+        pr.assembler.setCapturing(false); // turn capture off mid-run
 }
 
 static std::shared_ptr<mcdriver> make_driver(size_t nions, int nthreads)
@@ -75,27 +83,36 @@ static int check_probe(const char *tag, probe &pr)
     pr.assembler.flush();
 
     size_t tracks = 0, verts = 0;
+    std::set<uint64_t> cids;
     for (const auto &cc : pr.cascades) {
-        CHECK(!cc.tracks.empty());
-        CHECK(!cc.tracks.front().verts.empty());
-        CHECK(cc.tracks.front().verts.front().rid == 0);
-        for (const auto &t : cc.tracks) {
-            CHECK(!t.verts.empty());
-            tracks += 1;
-            verts += t.verts.size();
+        CHECK(!cc.buff.empty());
+        CHECK(cc.start_pos.size() == cc.length.size());
+        CHECK(!cc.start_pos.empty());
+        int32_t prev_end = 0;
+        for (size_t k = 0; k < cc.start_pos.size(); ++k) {
+            CHECK(cc.length[k] > 0);
+            CHECK(cc.start_pos[k] == prev_end); // tracks tile buff with no gaps
+            prev_end = cc.start_pos[k] + cc.length[k];
         }
+        CHECK(static_cast<size_t>(prev_end) == cc.buff.size());
+        CHECK(cc.buff[cc.start_pos[0]].rid == 0); // first track is the source ion
+        cids.insert(cc.id);
+        tracks += cc.start_pos.size();
+        verts += cc.buff.size();
     }
     std::cout << tag << ": source=" << pr.c.source << " recoil=" << pr.c.recoil
               << " scatter=" << pr.c.scatter << " end=" << pr.c.ended << " other=" << pr.c.other
-              << " | cascades=" << pr.cascades.size() << " tracks=" << tracks << " verts=" << verts
-              << std::endl;
+              << " | histories=" << pr.ids.size() << " cascades=" << pr.cascades.size()
+              << " tracks=" << tracks << " verts=" << verts << std::endl;
 
     CHECK(pr.c.source > 0);
     CHECK(pr.c.recoil > 0);
     CHECK(pr.c.scatter > 0);
     CHECK(pr.c.other == 0);
     CHECK(pr.c.source + pr.c.recoil == pr.c.ended);
-    CHECK(pr.cascades.size() == (size_t)pr.c.source);
+    CHECK(pr.assembler.dropped() == 0); // consumer kept up: no events dropped
+    CHECK(cids.size() == pr.cascades.size()); // cascade ids are unique
+    CHECK(pr.cascades.size() == pr.ids.size()); // one cascade per source-ion history
     CHECK(tracks == (size_t)(pr.c.source + pr.c.recoil));
     CHECK(verts > 0);
     return 0;
@@ -103,18 +120,19 @@ static int check_probe(const char *tag, probe &pr)
 
 int main()
 {
-    // single thread
+    // 1. single thread
     {
         auto D = make_driver(30, 1);
         CHECK(D);
         probe pr;
+        pr.assembler.setCapturing(true);
         CHECK(D->install_event_handler(probe_handler, CascadeAssembler::eventMask(), &pr, 0));
         D->exec(nullptr, 200);
         if (check_probe("single", pr))
             return 1;
     }
 
-    // no handler: the run must be untouched
+    // 2. no handler: the run must be untouched
     {
         auto D = make_driver(30, 1);
         CHECK(D);
@@ -125,15 +143,61 @@ int main()
         CHECK(ran > 0);
     }
 
-    // 4 threads, more ions
+    // 3. 4 threads, more ions
     {
         auto D = make_driver(200, 4);
         CHECK(D);
         probe pr;
+        pr.assembler.setCapturing(true);
         CHECK(D->install_event_handler(probe_handler, CascadeAssembler::eventMask(), &pr, 0));
         D->exec(nullptr, 200);
         if (check_probe("stress", pr))
             return 1;
+    }
+
+    // 4. recording overhead: the same run with capture off vs on
+    {
+        typedef std::chrono::steady_clock clock;
+
+        probe off; // capture stays off (default)
+        auto D0 = make_driver(50, 1);
+        CHECK(D0);
+        CHECK(D0->install_event_handler(probe_handler, CascadeAssembler::eventMask(), &off, 0));
+        clock::time_point t0 = clock::now();
+        D0->exec(nullptr, 200);
+        double ms_off = std::chrono::duration<double, std::milli>(clock::now() - t0).count();
+
+        probe on;
+        on.assembler.setCapturing(true);
+        auto D1 = make_driver(50, 1);
+        CHECK(D1);
+        CHECK(D1->install_event_handler(probe_handler, CascadeAssembler::eventMask(), &on, 0));
+        t0 = clock::now();
+        D1->exec(nullptr, 200);
+        double ms_on = std::chrono::duration<double, std::milli>(clock::now() - t0).count();
+
+        off.assembler.flush();
+        on.assembler.flush();
+
+        std::cout << "timing(50 ions): off=" << ms_off << "ms on=" << ms_on
+                  << "ms overhead=" << (ms_on - ms_off) << "ms dropped=" << on.assembler.dropped()
+                  << std::endl;
+        CHECK(off.cascades.empty()); // capture off: nothing recorded
+        CHECK(!on.cascades.empty()); // capture on: cascades recorded
+    }
+
+    // 5. capture disabled mid-run: flush must not emit a partial cascade
+    {
+        probe pr;
+        pr.disableAt = 100; // turn capture off inside the first cascade
+        pr.assembler.setCapturing(true);
+        auto D = make_driver(50, 1);
+        CHECK(D);
+        CHECK(D->install_event_handler(probe_handler, CascadeAssembler::eventMask(), &pr, 0));
+        D->exec(nullptr, 200);
+        pr.assembler.flush();
+        std::cout << "capture-off: cascades=" << pr.cascades.size() << std::endl;
+        CHECK(pr.cascades.empty()); // interrupted cascade discarded, not emitted
     }
 
     std::cout << "ALL PASS" << std::endl;


### PR DESCRIPTION
Delivers B-1 from the GSoC2026 Feature-B plan. This is the data side of the 3D viewer: it captures the simulation events and rebuilds ion tracks in memory for the viewport in B-2. No OpenGL yet.

## What this adds
- `CascadeAssembler` - rebuilds cascades (a source ion plus its recoils) from the event stream into 24-byte `TrackVertex` line strips. Plain C++, no Qt, so it is tested on its own.
- `TrackDataChannel` - installs a handler on sim thread 0 via `install_event_handler`, buffers finished cascades and passes them to the GUI thread with a queued `cascadeReady()`.
- `McDriverObj::setEventHandler()` - registers and installs the handler after `mcdriver::create`.
- `test_event_handling.cpp` - checks the events fire, transparency, and cascade assembly on 1 and 4 threads. Also fills in the existing `test_event_handling` target so tests build again.

The handler sits in a separate testable class instead of inside `Track3DViewport`; the viewport owns a `TrackDataChannel` in B-2, where the tab is wired too.

## Tested
Ubuntu 24.04 (WSL), gcc 13. Build clean, `ctest -R event_handling` passes. The 4-thread run stays consistent (track starts == ends, one cascade per source ion). No change to mccore, mcdriver, HDF5, tallies or the Python bindings.