### PR TITLE
feat: Track3DViewport - QOpenGLWidget + camera + scene (B-2)

### DIFF
--- a/source/gui/CMakeLists.txt
+++ b/source/gui/CMakeLists.txt
@@ -24,6 +24,7 @@ set(GUI_HEADERS
     mcplotinfo.h
     cascadeassembler.h
     trackdatachannel.h
+    track3dviewport.h
 )
 
 set(GUI_SOURCES
@@ -47,7 +48,11 @@ set(GUI_SOURCES
     mcplotinfo.cpp
     cascadeassembler.cpp
     trackdatachannel.cpp
+    track3dviewport.cpp
 )
+
+# OpenGL for the 3D viewport
+find_package(Qt5 REQUIRED COMPONENTS OpenGL)
 
 set (GUI_TARGET ${PROJECT_NAME_LOWERCASE}-gui)
 
@@ -60,6 +65,7 @@ target_link_libraries(${GUI_TARGET}
 PRIVATE
     Qt5::Widgets
     Qt5::Svg
+    Qt5::OpenGL
     Qwt::Qwt
     QtDataBrowser::QtDataBrowser
     ${LIB_TARGET}

--- a/source/gui/assets/ionicons/cube-outline.svg
+++ b/source/gui/assets/ionicons/cube-outline.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg class="ionicon" viewBox="0 0 512 512" version="1.1"
+     xmlns="http://www.w3.org/2000/svg">
+  <path d="M448 341.37V170.61A32 32 0 00432.11 143l-152-88.46a47.94 47.94 0 00-48.24 0L79.89 143A32 32 0 0064 170.61v170.76A32 32 0 0079.89 369l152 88.46a48 48 0 0048.24 0l152-88.46A32 32 0 00448 341.37z"
+        fill="none" stroke="#ededed" stroke-linecap="round" stroke-linejoin="round" stroke-width="32"/>
+  <path d="M69 153.99l187 110 187-110M256 463.99v-200"
+        fill="none" stroke="#ededed" stroke-linecap="round" stroke-linejoin="round" stroke-width="32"/>
+</svg>

--- a/source/gui/mainui.cpp
+++ b/source/gui/mainui.cpp
@@ -7,8 +7,10 @@
 #include "simcontrolwidget.h"
 #include "resultsview.h"
 #include "tabularview.h"
+#include "track3dviewport.h"
 
 #include <QVBoxLayout>
+#include <QPushButton>
 
 #include <QJsonDocument>
 #include <QStatusBar>
@@ -49,10 +51,10 @@ MainUI::MainUI(QWidget *parent) : QWidget(parent), quickStartWidget(nullptr)
     pageButtonGrp = new QButtonGroup(this);
 
     QString iconFolder = ":/assets/ionicons/";
-    QStringList icons{ "grid-outline.png", "settings-outline.png", "list-outline.png",
-                       "bar-chart-outline.png" };
+    QStringList icons{ "grid-outline.png", "settings-outline.png", "cube-outline.svg",
+                       "list-outline.png", "bar-chart-outline.png" };
 
-    QStringList titles{ "Welcome", "Config", "Summary", "Data" };
+    QStringList titles{ "Welcome", "Config", "3D Vis", "Summary", "Data" };
     for (int i = 0; i < titles.count(); ++i) {
         pageButtonGrp->addButton(createSidebarButton(iconFolder + icons.at(i), titles.at(i)), i);
         sidebarLayout->addWidget(pageButtonGrp->button(i));
@@ -90,6 +92,8 @@ MainUI::MainUI(QWidget *parent) : QWidget(parent), quickStartWidget(nullptr)
 
     optionsView = new SimulationOptionsView(this);
     push(tr("Configuration"), optionsView);
+
+    push(tr("3D Visualization"), createTrackViewPage());
 
     // runView = new RunView(this);
     // push(tr("Run"), runView);
@@ -196,6 +200,48 @@ void MainUI::pop()
     _stackedWidget->removeWidget(currentWidget);
 
     // delete currentWidget; currentWidget = nullptr;
+}
+
+QWidget *MainUI::createTrackViewPage()
+{
+    trackView = new Track3DViewport(driverObj_, this);
+
+    // camera toolbar under the viewport
+    QWidget *bar = new QWidget;
+    QHBoxLayout *hbox = new QHBoxLayout(bar);
+    hbox->setContentsMargins(0, 0, 0, 0);
+
+    struct
+    {
+        const char *label;
+        int view;
+        bool home; // Home also fits the box
+    } btns[] = { { "Home", Track3DViewport::Iso, true },
+                 { "Front", Track3DViewport::Front, false },
+                 { "Top", Track3DViewport::Top, false },
+                 { "Left", Track3DViewport::Left, false },
+                 { "Iso", Track3DViewport::Iso, false } };
+
+    for (const auto &b : btns) {
+        QPushButton *bt = new QPushButton(tr(b.label));
+        const int v = b.view;
+        const bool home = b.home;
+        connect(bt, &QPushButton::clicked, trackView, [this, v, home]() {
+            if (home)
+                trackView->homeView();
+            else
+                trackView->setPresetView(v);
+        });
+        hbox->addWidget(bt);
+    }
+    hbox->addStretch();
+
+    QWidget *page = new QWidget;
+    QVBoxLayout *vbox = new QVBoxLayout(page);
+    vbox->setContentsMargins(0, 0, 0, 0);
+    vbox->addWidget(trackView, 1);
+    vbox->addWidget(bar);
+    return page;
 }
 
 QToolButton *MainUI::createSidebarButton(const QString &iconPath, const QString &title)

--- a/source/gui/mainui.h
+++ b/source/gui/mainui.h
@@ -18,6 +18,7 @@ class SimulationOptionsView;
 class RunView;
 class ResultsView;
 class TabularView;
+class Track3DViewport;
 
 #define V_SPACING 15
 
@@ -39,7 +40,13 @@ public:
     void push(const QString &title, QWidget *page);
     void pop();
 
-    enum PageId { idWelcomePage = 0, idConfigPage = 1, idRunPage = 2, idResultsPage = 3 };
+    enum PageId {
+        idWelcomePage = 0,
+        idConfigPage = 1,
+        idTrackViewPage = 2,
+        idSummaryPage = 3,
+        idResultsPage = 4
+    };
 
     PageId currentPage() const;
 
@@ -56,11 +63,13 @@ protected:
 
 private:
     QToolButton *createSidebarButton(const QString &iconPath, const QString &title);
+    QWidget *createTrackViewPage();
 
     McDriverObj *driverObj_;
 
     WelcomeView *welcomeView;
     // RunView *runView;
+    Track3DViewport *trackView;
     TabularView *tblView;
     ResultsView *resultsView;
     QStackedWidget *_stackedWidget;

--- a/source/gui/opentrim.qrc
+++ b/source/gui/opentrim.qrc
@@ -20,6 +20,7 @@
         <file>assets/ionicons/bar-chart-outline.svg</file>
         <file>assets/ionicons/list-outline.svg</file>
         <file>assets/ionicons/grid-outline.svg</file>
+        <file>assets/ionicons/cube-outline.svg</file>
         <file>assets/ionicons/settings-outline.svg</file>
         <file>assets/ionicons/settings-outline.png</file>
         <file>assets/ionicons/grid-outline.png</file>

--- a/source/gui/track3dviewport.cpp
+++ b/source/gui/track3dviewport.cpp
@@ -1,0 +1,362 @@
+#include "track3dviewport.h"
+
+#include "mcdriverobj.h"
+#include "trackdatachannel.h"
+
+#include <cmath>
+#include <unordered_map>
+
+#include <QDebug>
+#include <QMouseEvent>
+#include <QOpenGLShaderProgram>
+#include <QShowEvent>
+#include <QSurfaceFormat>
+#include <QWheelEvent>
+#include <QtMath>
+
+// pos (loc 0) + rgba color (loc 1), interleaved, 7 floats/vertex
+static const int kStride = 7 * sizeof(float);
+
+static const char *kVertSrc = R"(#version 330 core
+layout(location = 0) in vec3 aPos;
+layout(location = 1) in vec4 aColor;
+uniform mat4 uMvp;
+out vec4 vColor;
+void main() {
+    gl_Position = uMvp * vec4(aPos, 1.0);
+    vColor = aColor;
+}
+)";
+
+static const char *kFragSrc = R"(#version 330 core
+in vec4 vColor;
+out vec4 fragColor;
+void main() { fragColor = vColor; }
+)";
+
+static void putVertex(std::vector<float> &v, const QVector3D &p, float r, float g, float b, float a)
+{
+    v.push_back(p.x());
+    v.push_back(p.y());
+    v.push_back(p.z());
+    v.push_back(r);
+    v.push_back(g);
+    v.push_back(b);
+    v.push_back(a);
+}
+
+// 8 corners of an axis-aligned box, indexed by (x,y,z) bits
+static void corners(const QVector3D &lo, const QVector3D &hi, QVector3D c[8])
+{
+    c[0] = { lo.x(), lo.y(), lo.z() };
+    c[1] = { hi.x(), lo.y(), lo.z() };
+    c[2] = { hi.x(), hi.y(), lo.z() };
+    c[3] = { lo.x(), hi.y(), lo.z() };
+    c[4] = { lo.x(), lo.y(), hi.z() };
+    c[5] = { hi.x(), lo.y(), hi.z() };
+    c[6] = { hi.x(), hi.y(), hi.z() };
+    c[7] = { lo.x(), hi.y(), hi.z() };
+}
+
+static void appendBoxEdges(std::vector<float> &v, const QVector3D &lo, const QVector3D &hi,
+                           const QColor &col)
+{
+    QVector3D c[8];
+    corners(lo, hi, c);
+    static const int e[12][2] = { { 0, 1 }, { 1, 2 }, { 2, 3 }, { 3, 0 }, { 4, 5 }, { 5, 6 },
+                                  { 6, 7 }, { 7, 4 }, { 0, 4 }, { 1, 5 }, { 2, 6 }, { 3, 7 } };
+    for (auto &ei : e) {
+        putVertex(v, c[ei[0]], col.redF(), col.greenF(), col.blueF(), col.alphaF());
+        putVertex(v, c[ei[1]], col.redF(), col.greenF(), col.blueF(), col.alphaF());
+    }
+}
+
+static void appendBoxFaces(std::vector<float> &v, const QVector3D &lo, const QVector3D &hi,
+                           const QColor &col)
+{
+    QVector3D c[8];
+    corners(lo, hi, c);
+    static const int f[6][4] = { { 0, 1, 2, 3 }, { 4, 5, 6, 7 }, { 0, 1, 5, 4 },
+                                 { 3, 2, 6, 7 }, { 0, 3, 7, 4 }, { 1, 2, 6, 5 } };
+    const float r = col.redF(), g = col.greenF(), b = col.blueF(), a = col.alphaF();
+    for (auto &fi : f) {
+        putVertex(v, c[fi[0]], r, g, b, a);
+        putVertex(v, c[fi[1]], r, g, b, a);
+        putVertex(v, c[fi[2]], r, g, b, a);
+        putVertex(v, c[fi[0]], r, g, b, a);
+        putVertex(v, c[fi[2]], r, g, b, a);
+        putVertex(v, c[fi[3]], r, g, b, a);
+    }
+}
+
+Track3DViewport::Track3DViewport(McDriverObj *driver, QWidget *parent)
+    : QOpenGLWidget(parent), driver_(driver)
+{
+    QSurfaceFormat fmt;
+    fmt.setVersion(3, 3);
+    fmt.setProfile(QSurfaceFormat::CoreProfile);
+    fmt.setDepthBufferSize(24);
+    fmt.setSamples(4);
+    setFormat(fmt);
+
+    setMinimumSize(320, 240);
+    setFocusPolicy(Qt::StrongFocus);
+
+    // register the handler before the run starts; capture stays off until playback
+    channel_ = new TrackDataChannel(this);
+    driver_->setEventHandler(TrackDataChannel::onEvent, TrackDataChannel::eventMask(), channel_);
+    connect(channel_, &TrackDataChannel::cascadeReady, this, &Track3DViewport::onCascadeReady,
+            Qt::QueuedConnection);
+
+    connect(driver_, &McDriverObj::configChanged, this, &Track3DViewport::refreshScene);
+    connect(driver_, &McDriverObj::simulationCreated, this, &Track3DViewport::refreshScene);
+}
+
+Track3DViewport::~Track3DViewport()
+{
+    // Don't touch driver_: McDriverObj is deleteLater'd with the runner thread
+    // (~MainUI) before this widget dies, so it may already be gone. Nothing to
+    // unregister anyway - the sim is stopped and the driver is torn down with it.
+    if (prog_ || boxVbo_.isCreated()) {
+        makeCurrent();
+        delete prog_;
+        prog_ = nullptr;
+        boxVbo_.destroy();
+        regVbo_.destroy();
+        boxVao_.destroy();
+        regVao_.destroy();
+        doneCurrent();
+    }
+}
+
+void Track3DViewport::initializeGL()
+{
+    initializeOpenGLFunctions();
+    glClearColor(0.10f, 0.10f, 0.12f, 1.0f);
+    glEnable(GL_DEPTH_TEST);
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+    prog_ = new QOpenGLShaderProgram(this);
+    if (!prog_->addShaderFromSourceCode(QOpenGLShader::Vertex, kVertSrc)
+        || !prog_->addShaderFromSourceCode(QOpenGLShader::Fragment, kFragSrc)
+        || !prog_->link())
+        qWarning() << "Track3DViewport: shader build failed:" << prog_->log();
+
+    boxVao_.create();
+    regVao_.create();
+    boxVbo_.create();
+    regVbo_.create();
+
+    readSceneFromConfig();
+    sceneDirty_ = true;
+}
+
+void Track3DViewport::resizeGL(int w, int h)
+{
+    glViewport(0, 0, w, h);
+}
+
+void Track3DViewport::paintGL()
+{
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    if (sceneDirty_)
+        buildSceneBuffers();
+    if (!prog_ || !prog_->isLinked())
+        return;
+
+    prog_->bind();
+    prog_->setUniformValue("uMvp", mvp());
+
+    // transparent regions first, without writing depth
+    if (regVertices_ > 0) {
+        glDepthMask(GL_FALSE);
+        regVao_.bind();
+        glDrawArrays(GL_TRIANGLES, 0, regVertices_);
+        regVao_.release();
+        glDepthMask(GL_TRUE);
+    }
+
+    if (boxVertices_ > 0) {
+        boxVao_.bind();
+        glDrawArrays(GL_LINES, 0, boxVertices_);
+        boxVao_.release();
+    }
+
+    prog_->release();
+}
+
+void Track3DViewport::showEvent(QShowEvent *e)
+{
+    QOpenGLWidget::showEvent(e);
+    readSceneFromConfig();
+    if (!viewInitialized_) {
+        viewInitialized_ = true;
+        homeView();
+    } else {
+        update();
+    }
+}
+
+void Track3DViewport::readSceneFromConfig()
+{
+    if (!driver_)
+        return;
+
+    const mcconfig &opt = driver_->options();
+    const auto &t = opt.Target;
+
+    boxMin_ = QVector3D(t.origin.x(), t.origin.y(), t.origin.z());
+    boxMax_ = boxMin_ + QVector3D(t.size.x(), t.size.y(), t.size.z());
+
+    std::unordered_map<std::string, size_t> mmap; // material_id -> index
+    for (size_t i = 0; i < t.materials.size(); ++i)
+        mmap[t.materials[i].id] = i;
+
+    regions_.clear();
+    for (const auto &r : t.regions) {
+        auto it = mmap.find(r.material_id);
+        QColor c = (it == mmap.end())
+                ? QColor(Qt::gray)
+                : QColor(QString::fromStdString(t.materials[it->second].color));
+        if (!c.isValid())
+            c = QColor(Qt::gray);
+        QVector3D x0(r.origin.x(), r.origin.y(), r.origin.z());
+        QVector3D x1 = x0 + QVector3D(r.size.x(), r.size.y(), r.size.z());
+        regions_.push_back({ x0, x1, c });
+    }
+
+    center_ = 0.5f * (boxMin_ + boxMax_);
+    radius_ = 0.5f * (boxMax_ - boxMin_).length();
+    if (radius_ < 1e-3f)
+        radius_ = 1.0f;
+    sceneDirty_ = true;
+}
+
+void Track3DViewport::buildSceneBuffers()
+{
+    std::vector<float> box, reg;
+
+    appendBoxEdges(box, boxMin_, boxMax_, QColor::fromRgbF(0.75, 0.75, 0.78, 1.0));
+    for (const RegionBox &rb : regions_) {
+        QColor c = rb.color;
+        c.setAlphaF(0.18); // weak transparent tint
+        appendBoxFaces(reg, rb.x0, rb.x1, c);
+    }
+
+    auto upload = [this](QOpenGLVertexArrayObject &vao, QOpenGLBuffer &vbo,
+                         const std::vector<float> &data) {
+        vao.bind();
+        vbo.bind();
+        vbo.allocate(data.data(), int(data.size() * sizeof(float)));
+        glEnableVertexAttribArray(0);
+        glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, kStride, nullptr);
+        glEnableVertexAttribArray(1);
+        glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, kStride,
+                              reinterpret_cast<void *>(3 * sizeof(float)));
+        vbo.release();
+        vao.release();
+    };
+
+    upload(boxVao_, boxVbo_, box);
+    upload(regVao_, regVbo_, reg);
+    boxVertices_ = int(box.size()) / 7;
+    regVertices_ = int(reg.size()) / 7;
+    sceneDirty_ = false;
+}
+
+QVector3D Track3DViewport::eye() const
+{
+    const float y = qDegreesToRadians(yaw_);
+    const float p = qDegreesToRadians(pitch_);
+    QVector3D dir(std::cos(p) * std::sin(y), std::sin(p), std::cos(p) * std::cos(y));
+    return center_ + dist_ * dir;
+}
+
+QMatrix4x4 Track3DViewport::mvp() const
+{
+    const float aspect = height() > 0 ? float(width()) / float(height()) : 1.0f;
+    QMatrix4x4 proj;
+    proj.perspective(45.0f, aspect, qMax(0.05f, radius_ * 0.05f), dist_ + radius_ * 4.0f);
+    QMatrix4x4 view;
+    view.lookAt(eye(), center_, QVector3D(0, 1, 0));
+    return proj * view;
+}
+
+void Track3DViewport::fitView()
+{
+    // fit the scene radius into the 45 deg fov, with margin
+    dist_ = radius_ / std::tan(qDegreesToRadians(22.5f)) * 1.15f;
+}
+
+void Track3DViewport::homeView()
+{
+    yaw_ = 45.0f;
+    pitch_ = 30.0f;
+    center_ = 0.5f * (boxMin_ + boxMax_);
+    fitView();
+    update();
+}
+
+void Track3DViewport::setPresetView(int v)
+{
+    switch (v) {
+    case Front: yaw_ = 0.0f; pitch_ = 0.0f; break;
+    case Back: yaw_ = 180.0f; pitch_ = 0.0f; break;
+    case Top: yaw_ = 0.0f; pitch_ = 89.0f; break;
+    case Bottom: yaw_ = 0.0f; pitch_ = -89.0f; break;
+    case Left: yaw_ = -90.0f; pitch_ = 0.0f; break;
+    case Right: yaw_ = 90.0f; pitch_ = 0.0f; break;
+    case Iso: default: yaw_ = 45.0f; pitch_ = 30.0f; break;
+    }
+    update();
+}
+
+void Track3DViewport::refreshScene()
+{
+    readSceneFromConfig();
+    update();
+}
+
+void Track3DViewport::onCascadeReady()
+{
+    // drain finished cascades (rendering is added later)
+    channel_->takeCascades();
+}
+
+void Track3DViewport::mousePressEvent(QMouseEvent *e)
+{
+    lastPos_ = e->pos();
+}
+
+void Track3DViewport::mouseMoveEvent(QMouseEvent *e)
+{
+    const int dx = e->x() - lastPos_.x();
+    const int dy = e->y() - lastPos_.y();
+    lastPos_ = e->pos();
+
+    if (e->buttons() & Qt::LeftButton) {
+        yaw_ -= dx * 0.3f;
+        pitch_ += dy * 0.3f;
+        pitch_ = qBound(-89.0f, pitch_, 89.0f);
+        update();
+    } else if (e->buttons() & (Qt::RightButton | Qt::MiddleButton)) {
+        QMatrix4x4 view;
+        view.lookAt(eye(), center_, QVector3D(0, 1, 0));
+        QVector3D right(view(0, 0), view(0, 1), view(0, 2));
+        QVector3D up(view(1, 0), view(1, 1), view(1, 2));
+        const float s = dist_ * 0.0015f;
+        center_ -= right * (dx * s);
+        center_ += up * (dy * s);
+        update();
+    }
+}
+
+void Track3DViewport::wheelEvent(QWheelEvent *e)
+{
+    const float steps = e->angleDelta().y() / 120.0f;
+    dist_ *= std::pow(0.9f, steps);
+    dist_ = qBound(radius_ * 0.1f, dist_, radius_ * 30.0f);
+    update();
+}

--- a/source/gui/track3dviewport.h
+++ b/source/gui/track3dviewport.h
@@ -1,0 +1,87 @@
+#ifndef TRACK3DVIEWPORT_H
+#define TRACK3DVIEWPORT_H
+
+#include <vector>
+
+#include <QColor>
+#include <QMatrix4x4>
+#include <QOpenGLBuffer>
+#include <QOpenGLFunctions_3_3_Core>
+#include <QOpenGLVertexArrayObject>
+#include <QOpenGLWidget>
+#include <QPoint>
+#include <QVector3D>
+
+class McDriverObj;
+class TrackDataChannel;
+class QOpenGLShaderProgram;
+
+// 3D viewport (QOpenGLWidget): target box + material regions + orbit camera.
+// Owns the TrackDataChannel and installs the core event handler.
+class Track3DViewport : public QOpenGLWidget, protected QOpenGLFunctions_3_3_Core
+{
+    Q_OBJECT
+public:
+    // preset camera angles
+    enum View { Front, Back, Top, Bottom, Left, Right, Iso };
+
+    explicit Track3DViewport(McDriverObj *driver, QWidget *parent = nullptr);
+    ~Track3DViewport() override;
+
+public slots:
+    void homeView(); // default angle, fit the box
+    void setPresetView(int v);
+    void refreshScene(); // rebuild from the config
+
+protected:
+    void initializeGL() override;
+    void resizeGL(int w, int h) override;
+    void paintGL() override;
+    void showEvent(QShowEvent *e) override;
+
+    void mousePressEvent(QMouseEvent *e) override;
+    void mouseMoveEvent(QMouseEvent *e) override;
+    void wheelEvent(QWheelEvent *e) override;
+
+private slots:
+    void onCascadeReady(); // GUI thread; drains finished cascades
+
+private:
+    struct RegionBox
+    {
+        QVector3D x0, x1;
+        QColor color;
+    };
+
+    void readSceneFromConfig(); // fill boxMin_/boxMax_/regions_
+    void buildSceneBuffers(); // fill the box + region VBOs
+    QVector3D eye() const;
+    QMatrix4x4 mvp() const;
+    void fitView();
+
+    McDriverObj *driver_; // not owned
+    TrackDataChannel *channel_; // owned (QObject child)
+
+    // scene
+    QVector3D boxMin_, boxMax_;
+    std::vector<RegionBox> regions_;
+    bool sceneDirty_{ true };
+
+    // GL
+    QOpenGLShaderProgram *prog_{ nullptr };
+    QOpenGLVertexArrayObject boxVao_, regVao_;
+    QOpenGLBuffer boxVbo_{ QOpenGLBuffer::VertexBuffer };
+    QOpenGLBuffer regVbo_{ QOpenGLBuffer::VertexBuffer };
+    int boxVertices_{ 0 };
+    int regVertices_{ 0 };
+
+    // orbit camera
+    QVector3D center_; // look-at point
+    float radius_{ 100.f }; // scene radius
+    float dist_{ 300.f }; // eye distance
+    float yaw_{ 45.f }, pitch_{ 30.f }; // degrees, +pitch = eye above
+    QPoint lastPos_;
+    bool viewInitialized_{ false };
+};
+
+#endif // TRACK3DVIEWPORT_H


### PR DESCRIPTION
## B-2 - Viewport and Scene

Adds the 3D viewport, the camera, and the "3D Vis" tab, on top of the track data pipeline from B-1.

### Delivers
- **Track3DViewport**, a `QOpenGLWidget` (OpenGL 3.3 core) that draws the target bounding box and the material regions as a weak transparent tint, using the material colors from the config.
- An **orbit camera**: mouse rotate, pan and zoom, preset views (front, top, left, iso) and a home button that recenters and refits the box.
- A new **"3D Vis" tab** below Config ("3D Visualization" in the main area), with a small camera toolbar under the viewport.
- The **track pipeline is now wired to the GUI**: the viewport owns a `TrackDataChannel`, `McDriverObj` installs its handler on sim thread 0, and `cascadeReady` reaches the GUI thread through a queued connection.
- Links `Qt5::OpenGL` in the gui build.

### Not in this PR
- Track drawing (VBO line strips, shaders, playback, play/pause/clear) starts in **B-3**. Here capture is off and cascades are drained without being drawn.
- `TrackViewWidget` (the full control panel) is deferred to B-5. B-2 puts a minimal camera toolbar directly in MainUI so the viewport can be tested now.

### Tested
- `opentrim-gui` builds and links with Qt5 5.15.13 and `Qt5::OpenGL`.
- The B-1 `event_handling` test still passes (single 30/30, capture-off cascades=0; overhead off ~8%, on ~38%).
- ran the gui under wsl: the "3D Vis" tab shows the box & the camera controls work.