### PR TITLE
feat: track color modes, colorbar and limits (B-4)

### DIFF
--- a/source/gui/cascadeassembler.cpp
+++ b/source/gui/cascadeassembler.cpp
@@ -257,7 +257,7 @@ void CascadeAssembler::applyEvent(const RawEvent &r)
     switch (state_) {
     case State::WaitForIon:
         if (r.ev == Event::NewSourceIon) {
-            beginCascade(r.ion_id);
+            beginCascade(r);
             beginTrack(r.v);
             state_ = State::InTrack;
         }
@@ -268,7 +268,7 @@ void CascadeAssembler::applyEvent(const RawEvent &r)
         case Event::NewSourceIon: // fires once per source ion (core source flag)
             endTrack();
             handoff();
-            beginCascade(r.ion_id);
+            beginCascade(r);
             beginTrack(r.v);
             break;
         case Event::NewRecoil:
@@ -294,7 +294,7 @@ void CascadeAssembler::applyEvent(const RawEvent &r)
         switch (r.ev) {
         case Event::NewSourceIon:
             handoff();
-            beginCascade(r.ion_id);
+            beginCascade(r);
             beginTrack(r.v);
             state_ = State::InTrack;
             break;
@@ -309,11 +309,12 @@ void CascadeAssembler::applyEvent(const RawEvent &r)
     }
 }
 
-void CascadeAssembler::beginCascade(uint64_t id)
+void CascadeAssembler::beginCascade(const RawEvent &r)
 {
     current_ = Cascade();
-    current_.id = id;
+    current_.id = r.ion_id;
     current_.duration = 0.0f;
+    current_.energy_range = { r.v.energy, r.v.energy };
     current_.epoch = activeEpoch_;
     track_start_ = 0;
     current_.buff.reserve(kCascadeReserve);
@@ -358,6 +359,7 @@ void CascadeAssembler::endTrack()
         current_.start_pos.push_back(track_start_);
         current_.length.push_back(len);
         current_.duration = std::max(current_.duration, current_.buff.back().t);
+        current_.energy_range[0] = std::min(current_.energy_range[0], current_.buff.back().energy);
     }
 }
 

--- a/source/gui/cascadeassembler.cpp
+++ b/source/gui/cascadeassembler.cpp
@@ -56,6 +56,23 @@ void CascadeAssembler::setWrapThresholds(float tx, float ty, float tz)
     wrapThresh_[2] = tz;
 }
 
+void CascadeAssembler::setEnergyThreshold(float eV)
+{
+    std::lock_guard<std::mutex> lk(mtx_);
+    energyThresh_ = eV;
+}
+
+void CascadeAssembler::setGenCutoff(int g)
+{
+    std::lock_guard<std::mutex> lk(mtx_);
+    genCutoff_ = g;
+}
+
+void CascadeAssembler::setFilterEpoch(uint32_t e)
+{
+    captureEpoch_.store(e, std::memory_order_relaxed);
+}
+
 // -------------------- producer (simulation thread) --------------------
 
 CascadeAssembler::RawBuffer *CascadeAssembler::acquireFree()
@@ -87,6 +104,19 @@ void CascadeAssembler::feed(Event ev, const ion &i)
         return;
     }
 
+    const uint32_t ep = captureEpoch_.load(std::memory_order_relaxed);
+    if (cur_ != nullptr && cur_->epoch != ep) {
+        // filter changed: start a fresh-epoch buffer, drop any cascade open across it
+        if (cur_->count > 0) {
+            publishReady(cur_);
+            cur_ = nullptr;
+            sawGap_ = true;
+        } else {
+            cur_->epoch = ep;
+            cur_->resyncBefore = true;
+        }
+    }
+
     if (cur_ == nullptr) {
         cur_ = acquireFree();
         if (cur_ == nullptr) { // consumer behind: drop, resync at the next cascade
@@ -94,6 +124,7 @@ void CascadeAssembler::feed(Event ev, const ion &i)
             sawGap_ = true;
             return;
         }
+        cur_->epoch = ep;
         cur_->resyncBefore = sawGap_;
         sawGap_ = false;
     }
@@ -208,7 +239,10 @@ void CascadeAssembler::processBuffer(RawBuffer *b)
         activeWrapThresh_[0] = wrapThresh_[0];
         activeWrapThresh_[1] = wrapThresh_[1];
         activeWrapThresh_[2] = wrapThresh_[2];
+        activeEnergyThresh_ = energyThresh_;
+        activeGenCutoff_ = genCutoff_;
     }
+    activeEpoch_ = b->epoch;
     if (b->resyncBefore) { // a gap in the stream: drop the partial cascade
         current_ = Cascade();
         track_start_ = 0;
@@ -280,18 +314,27 @@ void CascadeAssembler::beginCascade(uint64_t id)
     current_ = Cascade();
     current_.id = id;
     current_.duration = 0.0f;
+    current_.epoch = activeEpoch_;
     track_start_ = 0;
     current_.buff.reserve(kCascadeReserve);
 }
 
 void CascadeAssembler::beginTrack(const TrackVertex &v)
 {
+    // keep the source ion (rid 0); filter recoils on their starting vertex
+    trackDropped_ = (v.rid > 0 && activeEnergyThresh_ > 0.f && v.energy < activeEnergyThresh_)
+            || (activeGenCutoff_ >= 0 && v.rid > activeGenCutoff_);
+    if (trackDropped_)
+        return;
     track_start_ = static_cast<int32_t>(current_.buff.size());
     addVertex(v);
 }
 
 void CascadeAssembler::addVertex(const TrackVertex &v)
 {
+    if (trackDropped_)
+        return;
+
     // drop the segment crossing a periodic boundary
     if (static_cast<int32_t>(current_.buff.size()) > track_start_) {
         const TrackVertex &p = current_.buff.back();
@@ -306,6 +349,10 @@ void CascadeAssembler::addVertex(const TrackVertex &v)
 
 void CascadeAssembler::endTrack()
 {
+    if (trackDropped_) {
+        trackDropped_ = false;
+        return;
+    }
     int32_t len = static_cast<int32_t>(current_.buff.size()) - track_start_;
     if (len > 0) {
         current_.start_pos.push_back(track_start_);

--- a/source/gui/cascadeassembler.h
+++ b/source/gui/cascadeassembler.h
@@ -34,6 +34,7 @@ struct Cascade
     std::vector<int32_t> start_pos;
     std::vector<int32_t> length;
     float duration{ 0.f };
+    std::array<float, 2> energy_range{ 0.f, 0.f }; // min, max
     uint32_t epoch{ 0 };
 };
 
@@ -113,7 +114,7 @@ private:
     void consumeLoop();
     void processBuffer(RawBuffer *b);
     void applyEvent(const RawEvent &r);
-    void beginCascade(uint64_t id);
+    void beginCascade(const RawEvent &r);
     void beginTrack(const TrackVertex &v);
     void addVertex(const TrackVertex &v);
     void endTrack();

--- a/source/gui/cascadeassembler.h
+++ b/source/gui/cascadeassembler.h
@@ -1,6 +1,7 @@
 #ifndef CASCADEASSEMBLER_H
 #define CASCADEASSEMBLER_H
 
+#include <array>
 #include <atomic>
 #include <condition_variable>
 #include <cstdint>

--- a/source/gui/cascadeassembler.h
+++ b/source/gui/cascadeassembler.h
@@ -34,6 +34,7 @@ struct Cascade
     std::vector<int32_t> start_pos;
     std::vector<int32_t> length;
     float duration{ 0.f };
+    uint32_t epoch{ 0 };
 };
 
 // Builds cascades from the event stream. feed() (sim thread) copies events into a
@@ -60,6 +61,10 @@ public:
     // per-axis wrap threshold [nm]; 1e30 disables an axis
     void setWrapThresholds(float tx, float ty, float tz);
 
+    void setEnergyThreshold(float eV); // 0 = off
+    void setGenCutoff(int g); // < 0 = off
+    void setFilterEpoch(uint32_t e);
+
 private:
     struct RawEvent
     {
@@ -74,6 +79,7 @@ private:
         std::vector<RawEvent> data; // fixed capacity, sized once at construction
         size_t count{ 0 };
         bool resyncBefore{ false }; // events were dropped before this buffer
+        uint32_t epoch{ 0 };
     };
 
     // Fixed FIFO of buffer pointers (guarded by mtx_). Never allocates.
@@ -121,6 +127,10 @@ private:
     int32_t track_start_{ 0 }; // first index of the open track in current_.buff
     sink_t sink_;
     float activeWrapThresh_[3]{ 1e30f, 1e30f, 1e30f }; // consumer snapshot, per buffer
+    float activeEnergyThresh_{ 0.f };
+    int activeGenCutoff_{ -1 };
+    uint32_t activeEpoch_{ 0 };
+    bool trackDropped_{ false };
 
     // ---- shared ----
     std::vector<std::unique_ptr<RawBuffer>> pool_;
@@ -132,7 +142,10 @@ private:
     std::atomic<bool> stop_{ false };
     std::atomic<bool> capturing_{ false }; // pass-through until the view is active
     std::atomic<uint64_t> dropped_{ 0 };
+    std::atomic<uint32_t> captureEpoch_{ 0 };
     float wrapThresh_[3]{ 1e30f, 1e30f, 1e30f }; // [nm] wrap-split config, written under mtx_
+    float energyThresh_{ 0.f }; // [eV] limit config, written under mtx_
+    int genCutoff_{ -1 };
     bool finalize_{ false };
     bool finalizeDone_{ false };
     bool finalizeDiscard_{ false }; // flush found capture off: drop the partial tail

--- a/source/gui/mainui.cpp
+++ b/source/gui/mainui.cpp
@@ -304,10 +304,10 @@ QWidget *MainUI::createTrackViewPage()
 
     hbox2->addWidget(new QLabel(tr("E min [eV]")));
     QDoubleSpinBox *eThrBox = new QDoubleSpinBox;
-    eThrBox->setRange(0.0, 1e9);
-    eThrBox->setDecimals(0);
-    connect(eThrBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged), R,
-            &CascadeRecorder::setEnergyThreshold);
+    eThrBox->setRange(0.001, 1e9);
+    eThrBox->setDecimals(3);
+    connect(eThrBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged), trackView,
+            &Track3DViewport::setEnergyThreshold);
     hbox2->addWidget(eThrBox);
 
     hbox2->addWidget(new QLabel(tr("Max gen")));

--- a/source/gui/mainui.cpp
+++ b/source/gui/mainui.cpp
@@ -240,7 +240,7 @@ QWidget *MainUI::createTrackViewPage()
 
     hbox->addWidget(new QLabel(tr("Cascades")));
     QSpinBox *nBox = new QSpinBox;
-    nBox->setRange(1, 20);
+    nBox->setRange(1, 100);
     nBox->setValue(R->nCascades());
     connect(nBox, QOverload<int>::of(&QSpinBox::valueChanged), R, &CascadeRecorder::setNCascades);
     hbox->addWidget(nBox);
@@ -302,10 +302,45 @@ QWidget *MainUI::createTrackViewPage()
     connect(logBox, &QCheckBox::toggled, trackView, &Track3DViewport::setEnergyLog);
     hbox2->addWidget(logBox);
 
+    QCheckBox *autoBox = new QCheckBox(tr("Auto E"));
+    autoBox->setChecked(trackView->energyAuto());
+    hbox2->addWidget(autoBox);
+
+    hbox2->addWidget(new QLabel(tr("E scale [eV]")));
+    QDoubleSpinBox *escaleMin = new QDoubleSpinBox;
+    escaleMin->setRange(0.001, 1e9);
+    escaleMin->setDecimals(3);
+    escaleMin->setValue(trackView->energyMin());
+    escaleMin->setEnabled(!trackView->energyAuto());
+    connect(escaleMin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), trackView,
+            &Track3DViewport::setEnergyUserMin);
+    hbox2->addWidget(escaleMin);
+
+    QDoubleSpinBox *escaleMax = new QDoubleSpinBox;
+    escaleMax->setRange(0.001, 1e9);
+    escaleMax->setDecimals(3);
+    escaleMax->setValue(trackView->energyMax());
+    escaleMax->setEnabled(!trackView->energyAuto());
+    connect(escaleMax, QOverload<double>::of(&QDoubleSpinBox::valueChanged), trackView,
+            &Track3DViewport::setEnergyUserMax);
+    hbox2->addWidget(escaleMax);
+
+    connect(autoBox, &QCheckBox::toggled, trackView, &Track3DViewport::setEnergyAuto);
+    connect(autoBox, &QCheckBox::toggled, escaleMin, &QWidget::setDisabled);
+    connect(autoBox, &QCheckBox::toggled, escaleMax, &QWidget::setDisabled);
+    connect(autoBox, &QCheckBox::toggled, trackView, [this, escaleMin, escaleMax](bool on) {
+        if (!on) {
+            QSignalBlocker b1(escaleMin), b2(escaleMax);
+            escaleMin->setValue(trackView->energyMin());
+            escaleMax->setValue(trackView->energyMax());
+        }
+    });
+
     hbox2->addWidget(new QLabel(tr("E min [eV]")));
     QDoubleSpinBox *eThrBox = new QDoubleSpinBox;
     eThrBox->setRange(0.001, 1e9);
     eThrBox->setDecimals(3);
+    eThrBox->setValue(trackView->energyMin());
     connect(eThrBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged), trackView,
             &Track3DViewport::setEnergyThreshold);
     hbox2->addWidget(eThrBox);
@@ -321,7 +356,7 @@ QWidget *MainUI::createTrackViewPage()
 
     hbox2->addWidget(new QLabel(tr("Mem [MB]")));
     QSpinBox *memBox = new QSpinBox;
-    memBox->setRange(0, 4096);
+    memBox->setRange(0, 2000);
     memBox->setSpecialValueText(tr("off"));
     connect(memBox, QOverload<int>::of(&QSpinBox::valueChanged), R,
             &CascadeRecorder::setMemoryCapMB);

--- a/source/gui/mainui.cpp
+++ b/source/gui/mainui.cpp
@@ -12,6 +12,8 @@
 #include <QVBoxLayout>
 #include <QPushButton>
 #include <QCheckBox>
+#include <QComboBox>
+#include <QSignalBlocker>
 #include <QSpinBox>
 #include <QDoubleSpinBox>
 #include <QLineEdit>
@@ -221,6 +223,7 @@ QWidget *MainUI::createTrackViewPage()
     capBt->setCheckable(true);
     connect(capBt, &QPushButton::toggled, R, &CascadeRecorder::capture);
     connect(trackView, &Track3DViewport::captureChanged, capBt, [capBt](bool on) {
+        QSignalBlocker block(capBt); // don't let setChecked re-emit toggled()
         capBt->setChecked(on); // reflect auto-stop
         capBt->setText(on ? tr("Capture off") : tr("Capture on"));
     });
@@ -282,11 +285,62 @@ QWidget *MainUI::createTrackViewPage()
         hbox->addWidget(bt);
     }
 
+    // color & limits toolbar
+    QWidget *bar2 = new QWidget;
+    QHBoxLayout *hbox2 = new QHBoxLayout(bar2);
+    hbox2->setContentsMargins(0, 0, 0, 0);
+
+    hbox2->addWidget(new QLabel(tr("Color")));
+    QComboBox *colorBox = new QComboBox;
+    colorBox->addItems({ tr("Generation"), tr("Energy"), tr("Species") });
+    connect(colorBox, QOverload<int>::of(&QComboBox::currentIndexChanged), trackView,
+            &Track3DViewport::setColorMode);
+    hbox2->addWidget(colorBox);
+
+    QCheckBox *logBox = new QCheckBox(tr("Log E"));
+    logBox->setChecked(trackView->energyLog());
+    connect(logBox, &QCheckBox::toggled, trackView, &Track3DViewport::setEnergyLog);
+    hbox2->addWidget(logBox);
+
+    hbox2->addWidget(new QLabel(tr("E min [eV]")));
+    QDoubleSpinBox *eThrBox = new QDoubleSpinBox;
+    eThrBox->setRange(0.0, 1e9);
+    eThrBox->setDecimals(0);
+    connect(eThrBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged), R,
+            &CascadeRecorder::setEnergyThreshold);
+    hbox2->addWidget(eThrBox);
+
+    hbox2->addWidget(new QLabel(tr("Max gen")));
+    QSpinBox *genBox = new QSpinBox;
+    genBox->setRange(-1, 20);
+    genBox->setValue(-1);
+    genBox->setSpecialValueText(tr("all"));
+    connect(genBox, QOverload<int>::of(&QSpinBox::valueChanged), R,
+            &CascadeRecorder::setGenCutoff);
+    hbox2->addWidget(genBox);
+
+    hbox2->addWidget(new QLabel(tr("Mem [MB]")));
+    QSpinBox *memBox = new QSpinBox;
+    memBox->setRange(0, 4096);
+    memBox->setSpecialValueText(tr("off"));
+    connect(memBox, QOverload<int>::of(&QSpinBox::valueChanged), R,
+            &CascadeRecorder::setMemoryCapMB);
+    hbox2->addWidget(memBox);
+
+    hbox2->addStretch();
+
+    TrackColorBar *colorBar = new TrackColorBar(trackView);
+
     QWidget *page = new QWidget;
     QVBoxLayout *vbox = new QVBoxLayout(page);
     vbox->setContentsMargins(0, 0, 0, 0);
-    vbox->addWidget(trackView, 1);
+    QHBoxLayout *center = new QHBoxLayout;
+    center->setContentsMargins(0, 0, 0, 0);
+    center->addWidget(trackView, 1);
+    center->addWidget(colorBar);
+    vbox->addLayout(center, 1);
     vbox->addWidget(bar);
+    vbox->addWidget(bar2);
     return page;
 }
 

--- a/source/gui/shaders/track.frag
+++ b/source/gui/shaders/track.frag
@@ -3,10 +3,33 @@
 in float vEnergy;
 in float vT;
 flat in int vRid;
+flat in int vAid;
 
 uniform float uTime; // playback time [ns]
+uniform int uColorMode; // 0 generation, 1 energy, 2 species
+uniform float uEnergyMin; // [eV]
+uniform float uEnergyMax; // [eV]
+uniform int uEnergyLog; // 1 = log scale
 
 out vec4 fragColor;
+
+// blue -> cyan -> green -> yellow -> red; mirrored in TrackColorBar::rampColor
+vec3 ramp(float t)
+{
+    t = clamp(t, 0.0, 1.0);
+    const vec3 c0 = vec3(0.0, 0.0, 1.0);
+    const vec3 c1 = vec3(0.0, 1.0, 1.0);
+    const vec3 c2 = vec3(0.0, 1.0, 0.0);
+    const vec3 c3 = vec3(1.0, 1.0, 0.0);
+    const vec3 c4 = vec3(1.0, 0.0, 0.0);
+    if (t < 0.25)
+        return mix(c0, c1, t / 0.25);
+    if (t < 0.50)
+        return mix(c1, c2, (t - 0.25) / 0.25);
+    if (t < 0.75)
+        return mix(c2, c3, (t - 0.50) / 0.25);
+    return mix(c3, c4, (t - 0.75) / 0.25);
+}
 
 // color by recoil generation
 vec3 genColor(int g)
@@ -18,9 +41,36 @@ vec3 genColor(int g)
     return vec3(0.35, 0.6, 1.0); // deeper recoils
 }
 
+// distinct hue per atom id; mirrored in TrackColorBar::speciesColor
+vec3 speciesColor(int a)
+{
+    float h = fract(float(a) * 0.618034);
+    vec3 p = abs(fract(vec3(h) + vec3(1.0, 2.0 / 3.0, 1.0 / 3.0)) * 6.0 - 3.0);
+    return clamp(p - 1.0, 0.0, 1.0);
+}
+
+float energyFraction()
+{
+    float e = vEnergy, lo = uEnergyMin, hi = uEnergyMax;
+    if (uEnergyLog == 1) {
+        e = log(max(e, 1.0));
+        lo = log(max(uEnergyMin, 1.0));
+        hi = log(max(uEnergyMax, 1.0));
+    }
+    return (hi > lo) ? (e - lo) / (hi - lo) : 0.0;
+}
+
 void main()
 {
     if (vT > uTime) // time evolution: hide vertices not yet reached
         discard;
-    fragColor = vec4(genColor(vRid), 1.0);
+
+    vec3 c;
+    if (uColorMode == 1)
+        c = ramp(energyFraction());
+    else if (uColorMode == 2)
+        c = speciesColor(vAid);
+    else
+        c = genColor(vRid);
+    fragColor = vec4(c, 1.0);
 }

--- a/source/gui/shaders/track.vert
+++ b/source/gui/shaders/track.vert
@@ -4,12 +4,14 @@ layout(location = 0) in vec3 aPos; // nm
 layout(location = 1) in float aEnergy; // eV
 layout(location = 2) in float aT; // ns
 layout(location = 3) in int aRid; // recoil generation
+layout(location = 4) in int aAid; // atom id
 
 uniform mat4 uMvp;
 
 out float vEnergy;
 out float vT;
 flat out int vRid;
+flat out int vAid;
 
 void main()
 {
@@ -17,4 +19,5 @@ void main()
     vEnergy = aEnergy;
     vT = aT;
     vRid = aRid;
+    vAid = aAid;
 }

--- a/source/gui/track3dviewport.cpp
+++ b/source/gui/track3dviewport.cpp
@@ -27,6 +27,7 @@ static const int kStride = kSceneFloats * sizeof(float);
 
 static const int kTrackVboBytes = 96 * 1024 * 1024;
 static const int kTrackVboVerts = kTrackVboBytes / int(sizeof(TrackVertex));
+static const int kMaxCapMB = 2000; // keep cap bytes < INT_MAX (QOpenGLBuffer::allocate)
 
 static const char *kVertSrc = R"(#version 330 core
 layout(location = 0) in vec3 aPos;
@@ -144,7 +145,7 @@ void CascadeRecorder::setPlaybackSpeed(double f)
 
 void CascadeRecorder::setNCascades(int n)
 {
-    n = qBound(1, n, 20);
+    n = qBound(1, n, 100);
     if (n == nCascades_)
         return;
     nCascades_ = n;
@@ -154,7 +155,7 @@ void CascadeRecorder::setNCascades(int n)
 
 void CascadeRecorder::setMemoryCapMB(int mb)
 {
-    mb = std::max(0, mb);
+    mb = qBound(0, mb, kMaxCapMB);
     if (mb == memCapMB_)
         return;
     memCapMB_ = mb;
@@ -167,6 +168,13 @@ void CascadeRecorder::setEnergyThreshold(double eV)
     channel_->setEnergyThreshold(static_cast<float>(std::max(0.0, eV)));
     bumpFilterEpoch_();
     stateMachine(Clear);
+}
+
+int CascadeRecorder::capVerts() const
+{
+    if (memCapMB_ <= 0)
+        return kTrackVboVerts;
+    return int(size_t(memCapMB_) * 1024 * 1024 / sizeof(TrackVertex));
 }
 
 void CascadeRecorder::setGenCutoff(int g)
@@ -302,8 +310,9 @@ void CascadeRecorder::onCascadeReady()
     for (const auto &c : channel_->takeCascades()) {
         if (!c || c->buff.empty())
             continue;
-        if (int(c->buff.size()) > kTrackVboVerts) {
-            qWarning() << "Track3DViewport: cascade too large to draw:" << c->buff.size();
+        if (int(c->buff.size()) > capVerts()) {
+            if (int(c->buff.size()) > kTrackVboVerts) // genuinely oversized, not just a small cap
+                qWarning() << "Track3DViewport: cascade too large to draw:" << c->buff.size();
             continue;
         }
         admitCascade(c);
@@ -318,9 +327,7 @@ bool CascadeRecorder::admitCascade(const std::shared_ptr<Cascade> &c)
     if (c->epoch != filterEpoch_)
         return false;
 
-    int cap = kTrackVboVerts;
-    if (memCapMB_ > 0)
-        cap = std::min<int>(cap, int(size_t(memCapMB_) * 1024 * 1024 / sizeof(TrackVertex)));
+    const int cap = capVerts();
 
     if (mode_ == Batch) {
         // check if we already have N cascades
@@ -480,6 +487,7 @@ void Track3DViewport::initializeGL()
     trackVao_.bind();
     trackVbo_.bind();
     trackVbo_.allocate(kTrackVboBytes);
+    trackVboBytes_ = kTrackVboBytes;
     const int stride = int(sizeof(TrackVertex));
     glEnableVertexAttribArray(0);
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, stride,
@@ -619,9 +627,7 @@ void Track3DViewport::readSceneFromConfig()
         radius_ = 1.0f;
     sceneDirty_ = true;
 
-    // get energy limits
-    energyDataMin_ = opt.Transport.min_energy;
-    energyDataMax_ = opt.IonBeam.energy_distribution.center;
+    updateEnergyRange_();
 }
 
 void Track3DViewport::buildSceneBuffers()
@@ -740,9 +746,17 @@ void Track3DViewport::rebuildTrackBuffer()
     int N = std::min(recorder_->nCascades(), int(cbuff.size()));
 
     trackVbo_.bind();
+
+    const int want = recorder_->memoryCapMB() > 0
+            ? recorder_->memoryCapMB() * 1024 * 1024
+            : kTrackVboBytes;
+    if (want != trackVboBytes_) {
+        trackVbo_.allocate(want);
+        trackVboBytes_ = want;
+    }
+
     int vbo_offset = 0;
     int track_offset = 0;
-    // float emin = 1e12f, emax = 0.f; // [eV]
     for (int r = 0; r < N; ++r) {
         const Cascade &c = *cbuff[r];
 
@@ -755,10 +769,6 @@ void Track3DViewport::rebuildTrackBuffer()
         int len = c.buff.size() * sizeof(TrackVertex);
         trackVbo_.write(vbo_offset, c.buff.data(), len);
         vbo_offset += len;
-
-        // if needeed
-        // emax = std::max(emax, c.energy_range[1]);
-        // emin = std::min(emin, c.energy_range[0]);
     }
     trackVbo_.release();
 }
@@ -783,8 +793,49 @@ void Track3DViewport::setEnergyLog(bool on)
 
 void Track3DViewport::setEnergyThreshold(double eV)
 {
+    energyThreshold_ = static_cast<float>(std::max(0.0, eV));
     recorder_->setEnergyThreshold(eV);
-    energyDataMin_ = eV;
+    updateEnergyRange_();
+}
+
+void Track3DViewport::setEnergyAuto(bool on)
+{
+    if (on == energyAuto_)
+        return;
+    if (!on) {
+        energyUserMin_ = energyDataMin_;
+        energyUserMax_ = energyDataMax_;
+    }
+    energyAuto_ = on;
+    updateEnergyRange_();
+}
+
+void Track3DViewport::setEnergyUserMin(double eV)
+{
+    energyUserMin_ = static_cast<float>(eV);
+    if (!energyAuto_)
+        updateEnergyRange_();
+}
+
+void Track3DViewport::setEnergyUserMax(double eV)
+{
+    energyUserMax_ = static_cast<float>(eV);
+    if (!energyAuto_)
+        updateEnergyRange_();
+}
+
+void Track3DViewport::updateEnergyRange_()
+{
+    if (energyAuto_) {
+        const auto &opt = driver_->options();
+        energyDataMin_ = std::max(static_cast<float>(opt.Transport.min_energy), energyThreshold_);
+        energyDataMax_ = static_cast<float>(opt.IonBeam.energy_distribution.center);
+    } else {
+        energyDataMin_ = energyUserMin_;
+        energyDataMax_ = energyUserMax_;
+    }
+    if (energyDataMax_ <= energyDataMin_)
+        energyDataMax_ = energyDataMin_ * 10.f;
     emit colorConfigChanged();
     update();
 }
@@ -849,6 +900,26 @@ Track3DViewport::RegionBox Track3DViewport::RegionBox::intersection(const Region
 
 // -------------------- TrackColorBar --------------------
 
+// axis divisions: decades in log, 1-2-5x10^n in linear
+static std::vector<double> axisTicks(double lo, double hi, bool log)
+{
+    std::vector<double> t;
+    if (hi <= lo)
+        return t;
+    if (log) {
+        for (int e = int(std::floor(std::log10(lo))); e <= int(std::ceil(std::log10(hi))); ++e)
+            t.push_back(std::pow(10.0, e));
+    } else {
+        const double raw = (hi - lo) / 4.0;
+        const double mag = std::pow(10.0, std::floor(std::log10(raw)));
+        const double n = raw / mag;
+        const double step = (n < 1.5 ? 1.0 : n < 3.0 ? 2.0 : n < 7.0 ? 5.0 : 10.0) * mag;
+        for (double v = std::ceil(lo / step) * step; v <= hi + step * 1e-6; v += step)
+            t.push_back(v);
+    }
+    return t;
+}
+
 static QColor genSwatch(int g)
 {
     switch (g) {
@@ -901,12 +972,23 @@ void TrackColorBar::paintEvent(QPaintEvent *)
         p.drawRect(bar);
         p.drawText(m, m + 12, QStringLiteral("E [eV]"));
 
-        const float lo = view_->energyMin(), hi = view_->energyMax();
-        const float mid = view_->energyLog() ? std::sqrt(lo * hi) : 0.5f * (lo + hi);
-        const int tx = bar.right() + 5;
-        p.drawText(tx, bar.top() + 4, QString::number(hi, 'g', 3));
-        p.drawText(tx, bar.center().y() + 4, QString::number(mid, 'g', 3));
-        p.drawText(tx, bar.bottom(), QString::number(lo, 'g', 3));
+        const double lo = std::max(1e-6, double(view_->energyMin()));
+        const double hi = std::max(lo * 1.0001, double(view_->energyMax()));
+        const bool logm = view_->energyLog();
+        const double llo = std::log10(lo), lhi = std::log10(hi);
+        const int tx = bar.right() + 4;
+        int lastY = bar.bottom() + 100;
+        for (double v : axisTicks(lo, hi, logm)) {
+            const double f = logm ? (std::log10(v) - llo) / (lhi - llo) : (v - lo) / (hi - lo);
+            if (f < -1e-3 || f > 1.0 + 1e-3)
+                continue;
+            const int y = bar.bottom() - int(f * bar.height());
+            p.drawLine(bar.right(), y, bar.right() + 3, y);
+            if (lastY - y < 12)
+                continue;
+            p.drawText(tx, y + 4, QString::number(v, 'g', 3));
+            lastY = y;
+        }
         return;
     }
 

--- a/source/gui/track3dviewport.cpp
+++ b/source/gui/track3dviewport.cpp
@@ -11,8 +11,11 @@
 
 #include <QDebug>
 #include <QHideEvent>
+#include <QLinearGradient>
 #include <QMouseEvent>
 #include <QOpenGLShaderProgram>
+#include <QPainter>
+#include <QPalette>
 #include <QShowEvent>
 #include <QSurfaceFormat>
 #include <QWheelEvent>
@@ -149,6 +152,35 @@ void CascadeRecorder::setNCascades(int n)
     emit needsUpdate();
 }
 
+void CascadeRecorder::setMemoryCapMB(int mb)
+{
+    mb = std::max(0, mb);
+    if (mb == memCapMB_)
+        return;
+    memCapMB_ = mb;
+    stateMachine(Clear);
+    emit needsUpdate();
+}
+
+void CascadeRecorder::setEnergyThreshold(double eV)
+{
+    channel_->setEnergyThreshold(static_cast<float>(std::max(0.0, eV)));
+    bumpFilterEpoch_();
+    stateMachine(Clear);
+}
+
+void CascadeRecorder::setGenCutoff(int g)
+{
+    channel_->setGenCutoff(g);
+    bumpFilterEpoch_();
+    stateMachine(Clear);
+}
+
+void CascadeRecorder::bumpFilterEpoch_()
+{
+    channel_->setFilterEpoch(++filterEpoch_);
+}
+
 void CascadeRecorder::setRingMode(bool on)
 {
     mode_ = on ? Ring : Batch;
@@ -228,6 +260,12 @@ void CascadeRecorder::stateMachine(Event e)
         break;
     case Finishing:
         switch (e) {
+        case Start:
+            clear_();
+            clock_.start();
+            channel_->setCapturing(true);
+            state_ = Capturing;
+            break;
         case Update:
             if (clock_.playbackTime() > tMax_) {
                 clock_.pause();
@@ -277,13 +315,20 @@ bool CascadeRecorder::admitCascade(const std::shared_ptr<const Cascade> &c)
     if (state_ != Capturing)
         return false;
 
+    if (c->epoch != filterEpoch_)
+        return false;
+
+    int cap = kTrackVboVerts;
+    if (memCapMB_ > 0)
+        cap = std::min<int>(cap, int(size_t(memCapMB_) * 1024 * 1024 / sizeof(TrackVertex)));
+
     if (mode_ == Batch) {
         // check if we already have N cascades
         if (int(cascade_buffer_.size()) == nCascades_)
             return false;
 
         // check if it fits in the free space
-        int free = kTrackVboVerts;
+        int free = cap;
         for (const auto &r : cascade_buffer_)
             free -= int(r->buff.size());
         if (free < int(c->buff.size()))
@@ -305,7 +350,7 @@ bool CascadeRecorder::admitCascade(const std::shared_ptr<const Cascade> &c)
             return false;
 
         // check if it fits in the free space
-        int free = kTrackVboVerts;
+        int free = cap;
         for (const auto &r : cascade_buffer_)
             free -= int(r->buff.size());
         if (free < int(c->buff.size()))
@@ -433,6 +478,9 @@ void Track3DViewport::initializeGL()
     glEnableVertexAttribArray(3);
     glVertexAttribIPointer(3, 1, GL_SHORT, stride,
                            reinterpret_cast<void *>(offsetof(TrackVertex, rid)));
+    glEnableVertexAttribArray(4);
+    glVertexAttribIPointer(4, 1, GL_SHORT, stride,
+                           reinterpret_cast<void *>(offsetof(TrackVertex, aid)));
     trackVbo_.release();
     trackVao_.release();
 
@@ -483,6 +531,10 @@ void Track3DViewport::paintGL()
         trackProg_->bind();
         trackProg_->setUniformValue("uMvp", mvp());
         trackProg_->setUniformValue("uTime", static_cast<GLfloat>(recorder_->playbackTime()));
+        trackProg_->setUniformValue("uColorMode", colorMode_);
+        trackProg_->setUniformValue("uEnergyMin", energyDataMin_);
+        trackProg_->setUniformValue("uEnergyMax", energyDataMax_);
+        trackProg_->setUniformValue("uEnergyLog", energyLog_ ? 1 : 0);
         trackVao_.bind();
         glMultiDrawArrays(GL_LINE_STRIP, first_.data(), count_.data(), int(first_.size()));
         trackVao_.release();
@@ -675,18 +727,26 @@ void Track3DViewport::rebuildTrackBuffer()
     all.reserve(total);
     int base = 0;
     float t0 = recorder_->tMin(); // window-relative start of the cascade
+    float emin = 0.f, emax = 0.f; // [eV]
     for (int r = 0; r < N; ++r) {
-        for (size_t j = 0; j < cbuff[r]->start_pos.size(); ++j) {
-            first_.push_back(base + cbuff[r]->start_pos[j]);
-            count_.push_back(cbuff[r]->length[j]);
+        const Cascade &c = *cbuff[r];
+        for (size_t j = 0; j < c.start_pos.size(); ++j) {
+            first_.push_back(base + c.start_pos[j]);
+            count_.push_back(c.length[j]);
         }
         // lay this cascade end-to-end on the window-relative time axis
-        size_t i = all.size(), n = cbuff[r]->buff.size() + i;
-        all.insert(all.end(), cbuff[r]->buff.begin(), cbuff[r]->buff.end());
-        for (; i < n; ++i)
+        size_t i = all.size(), n = c.buff.size() + i;
+        all.insert(all.end(), c.buff.begin(), c.buff.end());
+        for (; i < n; ++i) {
             all[i].t += t0;
-        t0 += cbuff[r]->duration;
-        base += int(cbuff[r]->buff.size());
+            const float e = all[i].energy;
+            if (e > 0.f) {
+                emin = (emin == 0.f) ? e : std::min(emin, e);
+                emax = std::max(emax, e);
+            }
+        }
+        t0 += c.duration;
+        base += int(c.buff.size());
     }
 
     if (!all.empty()) {
@@ -694,6 +754,34 @@ void Track3DViewport::rebuildTrackBuffer()
         trackVbo_.write(0, all.data(), int(all.size() * sizeof(TrackVertex)));
         trackVbo_.release();
     }
+
+    if (emin <= 0.f)
+        emin = 1.f;
+    if (emax <= emin)
+        emax = emin;
+    if (emin != energyDataMin_ || emax != energyDataMax_) {
+        energyDataMin_ = emin;
+        energyDataMax_ = emax;
+        emit colorConfigChanged();
+    }
+}
+
+void Track3DViewport::setColorMode(int m)
+{
+    if (m == colorMode_)
+        return;
+    colorMode_ = m;
+    emit colorConfigChanged();
+    update();
+}
+
+void Track3DViewport::setEnergyLog(bool on)
+{
+    if (on == energyLog_)
+        return;
+    energyLog_ = on;
+    emit colorConfigChanged();
+    update();
 }
 
 void Track3DViewport::onRecorderStateChange(CascadeRecorder::State from, CascadeRecorder::State to)
@@ -752,4 +840,82 @@ Track3DViewport::RegionBox Track3DViewport::RegionBox::intersection(const Region
     b.x1.setY(std::min(b.x1.y(), other.x1.y()));
     b.x1.setZ(std::min(b.x1.z(), other.x1.z()));
     return b;
+}
+
+// -------------------- TrackColorBar --------------------
+
+static QColor genSwatch(int g)
+{
+    switch (g) {
+    case 0: return QColor::fromRgbF(1.0, 0.85, 0.2);
+    case 1: return QColor::fromRgbF(1.0, 0.45, 0.1);
+    case 2: return QColor::fromRgbF(0.9, 0.2, 0.2);
+    case 3: return QColor::fromRgbF(0.6, 0.3, 0.8);
+    default: return QColor::fromRgbF(0.35, 0.6, 1.0);
+    }
+}
+
+QColor TrackColorBar::rampColor(float t)
+{
+    t = qBound(0.f, t, 1.f);
+    static const float c[5][3] = { { 0, 0, 1 }, { 0, 1, 1 }, { 0, 1, 0 },
+                                   { 1, 1, 0 }, { 1, 0, 0 } };
+    const float f = t * 4.f;
+    const int i = std::min(int(f), 3);
+    const float u = f - i;
+    return QColor::fromRgbF(c[i][0] * (1 - u) + c[i + 1][0] * u,
+                            c[i][1] * (1 - u) + c[i + 1][1] * u,
+                            c[i][2] * (1 - u) + c[i + 1][2] * u);
+}
+
+QColor TrackColorBar::speciesColor(int aid)
+{
+    float h = aid * 0.618034f;
+    h -= std::floor(h);
+    return QColor::fromHsvF(h, 1.0, 1.0);
+}
+
+TrackColorBar::TrackColorBar(Track3DViewport *view, QWidget *parent)
+    : QWidget(parent), view_(view)
+{
+    connect(view_, &Track3DViewport::colorConfigChanged, this, QOverload<>::of(&QWidget::update));
+}
+
+void TrackColorBar::paintEvent(QPaintEvent *)
+{
+    QPainter p(this);
+    p.setPen(palette().color(QPalette::WindowText));
+    const int m = 6;
+
+    if (view_->colorMode() == Track3DViewport::Energy) {
+        const QRect bar(m, m + 16, 20, height() - 2 * m - 16);
+        QLinearGradient g(bar.topLeft(), bar.bottomLeft());
+        for (int k = 0; k <= 16; ++k)
+            g.setColorAt(k / 16.0, rampColor(1.f - k / 16.f)); // high E on top
+        p.fillRect(bar, g);
+        p.drawRect(bar);
+        p.drawText(m, m + 12, QStringLiteral("E [eV]"));
+
+        const float lo = view_->energyMin(), hi = view_->energyMax();
+        const float mid = view_->energyLog() ? std::sqrt(lo * hi) : 0.5f * (lo + hi);
+        const int tx = bar.right() + 5;
+        p.drawText(tx, bar.top() + 4, QString::number(hi, 'g', 3));
+        p.drawText(tx, bar.center().y() + 4, QString::number(mid, 'g', 3));
+        p.drawText(tx, bar.bottom(), QString::number(lo, 'g', 3));
+        return;
+    }
+
+    const bool species = view_->colorMode() == Track3DViewport::Species;
+    p.drawText(m, m + 12, species ? QStringLiteral("Species") : QStringLiteral("Gen."));
+    const int n = species ? 6 : 5;
+    for (int i = 0; i < n; ++i) {
+        const int y = m + 20 + i * 22;
+        const QRect sw(m, y, 16, 16);
+        p.fillRect(sw, species ? speciesColor(i) : genSwatch(i));
+        p.drawRect(sw);
+        QString lbl = species ? QStringLiteral("#%1").arg(i)
+                              : (i == 0 ? QStringLiteral("source")
+                                        : (i == 4 ? QStringLiteral("4+") : QString::number(i)));
+        p.drawText(sw.right() + 6, y + 13, lbl);
+    }
 }

--- a/source/gui/track3dviewport.cpp
+++ b/source/gui/track3dviewport.cpp
@@ -310,7 +310,7 @@ void CascadeRecorder::onCascadeReady()
     }
 }
 
-bool CascadeRecorder::admitCascade(const std::shared_ptr<const Cascade> &c)
+bool CascadeRecorder::admitCascade(const std::shared_ptr<Cascade> &c)
 {
     if (state_ != Capturing)
         return false;
@@ -333,12 +333,20 @@ bool CascadeRecorder::admitCascade(const std::shared_ptr<const Cascade> &c)
             free -= int(r->buff.size());
         if (free < int(c->buff.size()))
             return false;
-        // add cascade
-        cascade_buffer_.push_back(c);
+
         // the 1st cascade initializes tMin, tMax
-        if (cascade_buffer_.size() == 1) {
+        if (cascade_buffer_.empty()) {
             tMin_ = tMax_ = clock_.playbackTime();
         }
+
+        // update cascade timing
+        for (auto &v : c->buff)
+            v.t += tMax_;
+
+        // add cascade
+        cascade_buffer_.push_back(c);
+
+        // update state
         tMax_ += c->duration;
         tracksDirty_ = true;
         update();
@@ -356,12 +364,19 @@ bool CascadeRecorder::admitCascade(const std::shared_ptr<const Cascade> &c)
         if (free < int(c->buff.size()))
             return false;
 
-        // add cascade
-        cascade_buffer_.push_back(c);
         // the 1st cascade initializes tMin, tMax
-        if (cascade_buffer_.size() == 1) {
+        if (cascade_buffer_.empty()) {
             tMin_ = tMax_ = clock_.playbackTime();
         }
+
+        // update cascade timing
+        for (auto &v : c->buff)
+            v.t += tMax_;
+
+        // add cascade
+        cascade_buffer_.push_back(c);
+
+        // update state
         if (int(cascade_buffer_.size()) <= nCascades_) {
             tMax_ += c->duration;
             tracksDirty_ = true;
@@ -603,6 +618,10 @@ void Track3DViewport::readSceneFromConfig()
     if (radius_ < 1e-3f)
         radius_ = 1.0f;
     sceneDirty_ = true;
+
+    // get energy limits
+    energyDataMin_ = opt.Transport.min_energy;
+    energyDataMax_ = opt.IonBeam.energy_distribution.center;
 }
 
 void Track3DViewport::buildSceneBuffers()
@@ -717,53 +736,31 @@ void Track3DViewport::rebuildTrackBuffer()
     first_.clear();
     count_.clear();
 
-    int total = 0;
     const auto &cbuff = recorder_->cascade_buffer();
     int N = std::min(recorder_->nCascades(), int(cbuff.size()));
-    for (int r = 0; r < N; ++r)
-        total += int(cbuff[r]->buff.size());
 
-    std::vector<TrackVertex> all;
-    all.reserve(total);
-    int base = 0;
-    float t0 = recorder_->tMin(); // window-relative start of the cascade
-    float emin = 0.f, emax = 0.f; // [eV]
+    trackVbo_.bind();
+    int vbo_offset = 0;
+    int track_offset = 0;
+    // float emin = 1e12f, emax = 0.f; // [eV]
     for (int r = 0; r < N; ++r) {
         const Cascade &c = *cbuff[r];
+
         for (size_t j = 0; j < c.start_pos.size(); ++j) {
-            first_.push_back(base + c.start_pos[j]);
+            first_.push_back(track_offset + c.start_pos[j]);
             count_.push_back(c.length[j]);
         }
-        // lay this cascade end-to-end on the window-relative time axis
-        size_t i = all.size(), n = c.buff.size() + i;
-        all.insert(all.end(), c.buff.begin(), c.buff.end());
-        for (; i < n; ++i) {
-            all[i].t += t0;
-            const float e = all[i].energy;
-            if (e > 0.f) {
-                emin = (emin == 0.f) ? e : std::min(emin, e);
-                emax = std::max(emax, e);
-            }
-        }
-        t0 += c.duration;
-        base += int(c.buff.size());
-    }
+        track_offset += int(c.buff.size());
 
-    if (!all.empty()) {
-        trackVbo_.bind();
-        trackVbo_.write(0, all.data(), int(all.size() * sizeof(TrackVertex)));
-        trackVbo_.release();
-    }
+        int len = c.buff.size() * sizeof(TrackVertex);
+        trackVbo_.write(vbo_offset, c.buff.data(), len);
+        vbo_offset += len;
 
-    if (emin <= 0.f)
-        emin = 1.f;
-    if (emax <= emin)
-        emax = emin;
-    if (emin != energyDataMin_ || emax != energyDataMax_) {
-        energyDataMin_ = emin;
-        energyDataMax_ = emax;
-        emit colorConfigChanged();
+        // if needeed
+        // emax = std::max(emax, c.energy_range[1]);
+        // emin = std::min(emin, c.energy_range[0]);
     }
+    trackVbo_.release();
 }
 
 void Track3DViewport::setColorMode(int m)
@@ -780,6 +777,14 @@ void Track3DViewport::setEnergyLog(bool on)
     if (on == energyLog_)
         return;
     energyLog_ = on;
+    emit colorConfigChanged();
+    update();
+}
+
+void Track3DViewport::setEnergyThreshold(double eV)
+{
+    recorder_->setEnergyThreshold(eV);
+    energyDataMin_ = eV;
     emit colorConfigChanged();
     update();
 }

--- a/source/gui/track3dviewport.h
+++ b/source/gui/track3dviewport.h
@@ -153,6 +153,7 @@ private:
 
     void stateMachine(Event e);
     bool admitCascade(const std::shared_ptr<Cascade> &c);
+    int capVerts() const;
     void evictOldest();
     void statusUpdate_();
     void clear_();
@@ -177,6 +178,7 @@ public:
 
     int colorMode() const { return colorMode_; }
     bool energyLog() const { return energyLog_; }
+    bool energyAuto() const { return energyAuto_; }
     float energyMin() const { return energyDataMin_; } // [eV]
     float energyMax() const { return energyDataMax_; }
 
@@ -187,6 +189,9 @@ public slots:
     void setColorMode(int m);
     void setEnergyLog(bool on);
     void setEnergyThreshold(double eV);
+    void setEnergyAuto(bool on);
+    void setEnergyUserMin(double eV);
+    void setEnergyUserMax(double eV);
 
 signals:
     void captureChanged(bool on);
@@ -215,6 +220,7 @@ private:
     };
 
     void readSceneFromConfig();
+    void updateEnergyRange_();
     void buildSceneBuffers();
     QVector3D eye() const;
     QMatrix4x4 mvp() const;
@@ -239,11 +245,15 @@ private:
     QOpenGLShaderProgram *trackProg_{ nullptr };
     QOpenGLVertexArrayObject trackVao_;
     QOpenGLBuffer trackVbo_{ QOpenGLBuffer::VertexBuffer };
+    int trackVboBytes_{ 0 };
     std::vector<int> first_, count_; // glMultiDrawArrays args
 
     int colorMode_{ Generation };
     bool energyLog_{ true };
-    float energyDataMin_{ 1.f }, energyDataMax_{ 1.f }; // [eV]
+    bool energyAuto_{ true };
+    float energyThreshold_{ 0.f }; // [eV]
+    float energyDataMin_{ 1.f }, energyDataMax_{ 1.e6f }; // [eV]
+    float energyUserMin_{ 1.f }, energyUserMax_{ 1.e6f }; // [eV]
 
     QVector3D center_;
     float radius_{ 100.f };

--- a/source/gui/track3dviewport.h
+++ b/source/gui/track3dviewport.h
@@ -152,7 +152,7 @@ private:
     uint32_t filterEpoch_{ 0 };
 
     void stateMachine(Event e);
-    bool admitCascade(const std::shared_ptr<const Cascade> &c);
+    bool admitCascade(const std::shared_ptr<Cascade> &c);
     void evictOldest();
     void statusUpdate_();
     void clear_();
@@ -186,6 +186,7 @@ public slots:
     void refreshScene();
     void setColorMode(int m);
     void setEnergyLog(bool on);
+    void setEnergyThreshold(double eV);
 
 signals:
     void captureChanged(bool on);

--- a/source/gui/track3dviewport.h
+++ b/source/gui/track3dviewport.h
@@ -1,6 +1,7 @@
 #ifndef TRACK3DVIEWPORT_H
 #define TRACK3DVIEWPORT_H
 
+#include <cstdint>
 #include <deque>
 #include <memory>
 #include <vector>
@@ -13,7 +14,9 @@
 #include <QOpenGLVertexArrayObject>
 #include <QOpenGLWidget>
 #include <QPoint>
+#include <QSize>
 #include <QVector3D>
+#include <QWidget>
 
 class McDriverObj;
 class TrackDataChannel;
@@ -110,6 +113,7 @@ public:
     bool isRunning() const { return clock_.isRunning(); }
     double tMin() const { return tMin_; }
     double tMax() const { return tMax_; }
+    int memoryCapMB() const { return memCapMB_; }
 
 public slots:
     void capture(bool on) { stateMachine(on ? Start : Stop); }
@@ -118,6 +122,9 @@ public slots:
     void setNCascades(int n);
     void setRingMode(bool on);
     void setPlaybackSpeed(double f); // f [ns/s]
+    void setMemoryCapMB(int mb);
+    void setEnergyThreshold(double eV);
+    void setGenCutoff(int g);
     void update() { stateMachine(Update); }
 
 signals:
@@ -141,12 +148,15 @@ private:
     CascadeRecorderClock clock_;
     double tMin_{ 0.f }; // [ns] start of 1st displayed cascade
     double tMax_{ 0.f }; // [ns] end of last displayed cascade
+    int memCapMB_{ 0 }; // 0 = no cap
+    uint32_t filterEpoch_{ 0 };
 
     void stateMachine(Event e);
     bool admitCascade(const std::shared_ptr<const Cascade> &c);
     void evictOldest();
     void statusUpdate_();
     void clear_();
+    void bumpFilterEpoch_();
 };
 
 // 3D viewport (QOpenGLWidget): target box + material regions + orbit camera,
@@ -158,19 +168,28 @@ class Track3DViewport : public QOpenGLWidget, protected QOpenGLFunctions_3_3_Cor
 
 public:
     enum View { Front, Back, Top, Bottom, Left, Right, Iso };
+    enum ColorMode { Generation, Energy, Species };
 
     explicit Track3DViewport(McDriverObj *driver, QWidget *parent = nullptr);
     ~Track3DViewport() override;
 
     CascadeRecorder *cascadeRecorder() { return recorder_; }
 
+    int colorMode() const { return colorMode_; }
+    bool energyLog() const { return energyLog_; }
+    float energyMin() const { return energyDataMin_; } // [eV]
+    float energyMax() const { return energyDataMax_; }
+
 public slots:
     void homeView();
     void setPresetView(int v);
     void refreshScene();
+    void setColorMode(int m);
+    void setEnergyLog(bool on);
 
-signals:   
+signals:
     void captureChanged(bool on);
+    void colorConfigChanged();
 
 protected:
     void initializeGL() override;
@@ -221,12 +240,36 @@ private:
     QOpenGLBuffer trackVbo_{ QOpenGLBuffer::VertexBuffer };
     std::vector<int> first_, count_; // glMultiDrawArrays args
 
+    int colorMode_{ Generation };
+    bool energyLog_{ true };
+    float energyDataMin_{ 1.f }, energyDataMax_{ 1.f }; // [eV]
+
     QVector3D center_;
     float radius_{ 100.f };
     float dist_{ 300.f };
     float yaw_{ 45.f }, pitch_{ 30.f }; // degrees, +pitch = eye above
     QPoint lastPos_;
     bool viewInitialized_{ false };
+};
+
+// Legend next to the viewport: an energy gradient in Energy mode, else discrete
+// generation/species swatches. Repaints on the viewport's colorConfigChanged.
+class TrackColorBar : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit TrackColorBar(Track3DViewport *view, QWidget *parent = nullptr);
+    QSize sizeHint() const override { return QSize(84, 200); }
+
+    static QColor rampColor(float t); // mirrors track.frag ramp()
+    static QColor speciesColor(int aid); // mirrors track.frag speciesColor()
+
+protected:
+    void paintEvent(QPaintEvent *e) override;
+
+private:
+    Track3DViewport *view_; // not owned
 };
 
 #endif // TRACK3DVIEWPORT_H

--- a/source/gui/trackdatachannel.cpp
+++ b/source/gui/trackdatachannel.cpp
@@ -16,15 +16,15 @@ void TrackDataChannel::enqueue(Cascade &&c)
     {
         std::lock_guard<std::mutex> lock(mtx_);
         notify = ready_.empty();
-        ready_.push_back(std::make_shared<const Cascade>(std::move(c)));
+        ready_.push_back(std::make_shared<Cascade>(std::move(c)));
     }
     if (notify)
         emit cascadeReady();
 }
 
-std::vector<std::shared_ptr<const Cascade>> TrackDataChannel::takeCascades()
+std::vector<std::shared_ptr<Cascade>> TrackDataChannel::takeCascades()
 {
-    std::vector<std::shared_ptr<const Cascade>> out;
+    std::vector<std::shared_ptr<Cascade>> out;
     std::lock_guard<std::mutex> lock(mtx_);
     out.assign(ready_.begin(), ready_.end());
     ready_.clear();

--- a/source/gui/trackdatachannel.h
+++ b/source/gui/trackdatachannel.h
@@ -24,7 +24,7 @@ public:
 
     explicit TrackDataChannel(QObject *parent = nullptr);
 
-    std::vector<std::shared_ptr<const Cascade>> takeCascades();
+    std::vector<std::shared_ptr<Cascade>> takeCascades();
 
     bool isCapturing() const { return assembler_.isCapturing(); }
     void setWrapThresholds(float tx, float ty, float tz)
@@ -46,7 +46,7 @@ private:
     void enqueue(Cascade &&c); // runs on the assembler's consumer thread
 
     std::mutex mtx_;
-    std::deque<std::shared_ptr<const Cascade>> ready_;
+    std::deque<std::shared_ptr<Cascade>> ready_;
 
     // declared last: its consumer thread is joined before ready_/mtx_ are destroyed
     CascadeAssembler assembler_;

--- a/source/gui/trackdatachannel.h
+++ b/source/gui/trackdatachannel.h
@@ -31,6 +31,9 @@ public:
     {
         assembler_.setWrapThresholds(tx, ty, tz);
     }
+    void setEnergyThreshold(float eV) { assembler_.setEnergyThreshold(eV); }
+    void setGenCutoff(int g) { assembler_.setGenCutoff(g); }
+    void setFilterEpoch(uint32_t e) { assembler_.setFilterEpoch(e); }
 
 public slots:
     void setCapturing(bool on) { assembler_.setCapturing(on); }

--- a/test/cpp/test_event_handling.cpp
+++ b/test/cpp/test_event_handling.cpp
@@ -21,6 +21,9 @@ struct probe
     std::set<uint64_t> ids; // distinct source-ion history ids
     int disableAt{ -1 }; // event index at which to turn capture off (-1 = never)
     int seen{ 0 };
+    int bumpAt{ -1 }; // source-ion count at which to bump the epoch (-1 = never)
+    bool bumped{ false };
+    std::set<uint64_t> preBumpIds;
     std::vector<Cascade> cascades;
     CascadeAssembler assembler; // last: joined before cascades/ids on destruction
 
@@ -34,6 +37,8 @@ static void probe_handler(Event ev, const ion &i, void *p)
     case Event::NewSourceIon:
         pr.c.source++;
         pr.ids.insert(static_cast<uint64_t>(i.ion_id()));
+        if (pr.bumpAt >= 0 && !pr.bumped)
+            pr.preBumpIds.insert(static_cast<uint64_t>(i.ion_id()));
         break;
     case Event::NewRecoil:
         pr.c.recoil++;
@@ -53,6 +58,10 @@ static void probe_handler(Event ev, const ion &i, void *p)
     pr.assembler.feed(ev, i);
     if (pr.disableAt >= 0 && ++pr.seen == pr.disableAt)
         pr.assembler.setCapturing(false); // turn capture off mid-run
+    if (pr.bumpAt >= 0 && !pr.bumped && pr.c.source >= pr.bumpAt) {
+        pr.assembler.setFilterEpoch(1);
+        pr.bumped = true;
+    }
 }
 
 static std::shared_ptr<mcdriver> make_driver(size_t nions, int nthreads)
@@ -218,6 +227,87 @@ int main()
         pr.assembler.flush();
         std::cout << "capture-off: cascades=" << pr.cascades.size() << std::endl;
         CHECK(pr.cascades.empty()); // interrupted cascade discarded, not emitted
+    }
+
+    // 6. limits filter at the source: dropped tracks never stored, source ion kept
+    {
+        size_t tracks_ref = 0;
+        {
+            probe ref;
+            ref.assembler.setCapturing(true);
+            auto D = make_driver(50, 1);
+            CHECK(D);
+            CHECK(D->install_event_handler(probe_handler, CascadeAssembler::eventMask(), &ref, 0));
+            D->exec(nullptr, 200);
+            ref.assembler.flush();
+            for (const auto &cc : ref.cascades)
+                tracks_ref += cc.start_pos.size();
+        }
+
+        probe g; // generation cutoff
+        g.assembler.setCapturing(true);
+        g.assembler.setGenCutoff(1);
+        g.assembler.setFilterEpoch(7);
+        auto Dg = make_driver(50, 1);
+        CHECK(Dg);
+        CHECK(Dg->install_event_handler(probe_handler, CascadeAssembler::eventMask(), &g, 0));
+        Dg->exec(nullptr, 200);
+        g.assembler.flush();
+        size_t tracks_g = 0;
+        for (const auto &cc : g.cascades) {
+            CHECK(cc.epoch == 7);
+            CHECK(cc.buff[cc.start_pos[0]].rid == 0); // source ion kept
+            for (size_t k = 0; k < cc.start_pos.size(); ++k)
+                CHECK(cc.buff[cc.start_pos[k]].rid <= 1);
+            tracks_g += cc.start_pos.size();
+        }
+        CHECK(!g.cascades.empty());
+        CHECK(tracks_g < tracks_ref); // deeper generations dropped
+
+        probe e; // energy threshold
+        e.assembler.setCapturing(true);
+        e.assembler.setEnergyThreshold(1000.f);
+        auto De = make_driver(50, 1);
+        CHECK(De);
+        CHECK(De->install_event_handler(probe_handler, CascadeAssembler::eventMask(), &e, 0));
+        De->exec(nullptr, 200);
+        e.assembler.flush();
+        for (const auto &cc : e.cascades) {
+            CHECK(cc.buff[cc.start_pos[0]].rid == 0); // source ion kept
+            for (size_t k = 0; k < cc.start_pos.size(); ++k) {
+                const TrackVertex &v = cc.buff[cc.start_pos[k]];
+                if (v.rid > 0)
+                    CHECK(v.energy >= 1000.f); // recoils start at/above the threshold
+            }
+        }
+        CHECK(!e.cascades.empty());
+        std::cout << "limits: ref_tracks=" << tracks_ref << " gen<=1_tracks=" << tracks_g
+                  << " e>=1keV cascades=" << e.cascades.size() << std::endl;
+    }
+
+    // 7. filter change mid-capture: cascades captured before it keep the old epoch
+    //    (recorder rejects them), later ones get the new one (capture-time stamp)
+    {
+        probe pr;
+        pr.assembler.setCapturing(true);
+        pr.bumpAt = 5; // bump after the 5th source ion
+        auto D = make_driver(50, 1);
+        CHECK(D);
+        CHECK(D->install_event_handler(probe_handler, CascadeAssembler::eventMask(), &pr, 0));
+        D->exec(nullptr, 200);
+        pr.assembler.flush();
+        CHECK(pr.bumped);
+        bool sawNew = false;
+        for (const auto &cc : pr.cascades) {
+            CHECK(cc.epoch == 0 || cc.epoch == 1);
+            if (pr.preBumpIds.count(cc.id))
+                CHECK(cc.epoch == 0); // pre-change capture never gets the new epoch
+            if (cc.epoch == 1)
+                sawNew = true;
+        }
+        CHECK(sawNew); // post-change captures appear
+        std::cout << "active-change: cascades=" << pr.cascades.size()
+                  << " pre=" << pr.preBumpIds.size() << std::endl;
     }
 
     std::cout << "ALL PASS" << std::endl;


### PR DESCRIPTION
B-4 - Track color modes, colorbar and limits

Adds color coding, a colorbar and the limits on top of B-3 track rendering.

### Delivers
- Color by generation, energy or species, with an optional log energy scale.
- Colorbar next to the viewport: gradient for energy, swatches for generation/species.
- Three limits: energy threshold, generation cutoff and a memory cap. Energy and generation filtering runs in CascadeAssembler, so dropped tracks are never stored. A limit change clears the buffer; a capture-time epoch drops in-flight cascades from the old filter.
- Second toolbar row: Color / Log E / E-min / Max-gen / Mem-MB.

Also fixes two pre-existing capture-button bugs found while testing: the reflect handler re-emitted toggled() and Finishing ignored a new Capture-on click.

### Not in this PR
- The full control panel (View / Playback / Color / Limits) is B-5.
- Species legend shows the atom-id index, not element symbols (B-5).
- The memory cap bounds admission but doesn't stop capture once full.

### Tested
- opentrim-gui builds; the B-1 event_handling test still passes, plus two new cases: source-level filtering and a mid-capture limit change dropping stale cascades.
- 2 MeV Fe on Fe: color modes, colorbar, log toggle and all three limits work; capture on/off holds across tab hide/show and play-out restart.